### PR TITLE
Implement generalized gamma distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ htmlcov/
 dist/*
 virocon.egg-info/*
 .vscode
+.spyproject

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -149,15 +149,15 @@ def test_fit_exponentiated_weibull_with_zero():
 
 def test_generalized_gamma_reproduce_Ochi_CDF():
     """
-    Test reproducing the fitting of Ochi et. al (1980) and compare it to
+    Test reproducing the fitting of Ochi et. al (1992) and compare it to
     virocons implementation of the generalized gamma distribution. The results
     should be the same.
 
     """
 
     # Define dist with parameters from the distribution of Fig. 4b in
-    # M.K. Ochi, J.E. Wahlen, New approach for estimating the severes
-    # sea state from statistical data , Coast. Eng. Chapter 38 (1992) 
+    # M.K. Ochi, New approach for estimating the severest sea state from 
+    # statistical data , Coast. Eng. Chapter 38 (1992) 
     # pp. 512-525.
     
     dist = GeneralizedGammaDistribution(1.60, 0.98, 1.37)

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -189,9 +189,9 @@ def test_generalized_gamma_reproduce_Ochi_CDF():
     
 def test_generalized_gamma_compare_scipy_to_virocon_PDF():
     """
-    Test which compares the PDF of a fitted distribution with scipy and 
-    compare it to the PDF of a fitted distribution with virocon. The results 
-    should be the same since virocon uses scipy.
+    Test which compares the PDF of a fitted scipy distribution and compare it 
+    to the PDF of a fitted virocon distribution. The results should be the 
+    same since virocon uses scipy.
 
     """  
     
@@ -220,9 +220,9 @@ def test_generalized_gamma_compare_scipy_to_virocon_PDF():
     
 def test_generalized_gamma_compare_scipy_to_virocon_ICDF():
     """
-    Test which compares the ICDF of a fitted distribution with scipy and 
-    compare it to the ICDF of a fitted distribution with virocon. The results 
-    should be the same since virocon uses scipy.
+    Test which compares the ICDF of a fitted scipy distribution and compare it 
+    to the ICDF of a fitted virocon distribution. The results should be the 
+    same since virocon uses scipy.
 
     """  
     

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -189,14 +189,15 @@ def test_generalized_gamma_reproduce_Ochi_CDF():
     
 def test_generalized_gamma_compare_scipy_to_virocon_PDF():
     """
-    Test comparing the PDF a fitted distribution with scipy and compare it to
-    virocons PDF. The results should be the same since virocon uses scipy.
+    Test which compares the PDF of a fitted distribution with scipy and 
+    compare it to the PDF of a fitted distribution with virocon. The results 
+    should be the same since virocon uses scipy.
 
     """  
     
-    # Create sample 
     x = np.linspace(2, 15, num=100)
     
+    # Create sample 
     true_m = 5
     true_c = 2.42
     true_loc = 0
@@ -219,14 +220,15 @@ def test_generalized_gamma_compare_scipy_to_virocon_PDF():
     
 def test_generalized_gamma_compare_scipy_to_virocon_ICDF():
     """
-    Test comparing the PDF a fitted distribution with scipy and compare it to
-    virocons PDF. The results should be the same since virocon uses scipy.
+    Test which compares the ICDF of a fitted distribution with scipy and 
+    compare it to the ICDF of a fitted distribution with virocon. The results 
+    should be the same since virocon uses scipy.
 
     """  
     
-    # Create sample 
     p = np.linspace(0.01, 0.99, num=100)
     
+    # Create sample 
     true_m = 5
     true_c = 2.42
     true_loc = 0

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -145,20 +145,20 @@ def test_fit_exponentiated_weibull_with_zero():
     assert dist.parameters["beta"] == pytest.approx(1.5, abs=0.5)
     assert dist.parameters["alpha"] == pytest.approx(3, abs=1)
     assert dist.parameters["delta"] == pytest.approx(1, abs=0.5)
-    
-    
+
+
 def test_generalized_gamma_reproduce_Ochi_CDF():
     """
     Test reproducing the fitting of Ochi et. al (1980) and compare it to
     virocons implementation of the generalized gamma distribution. The results
     should be the same.
 
-    """  
-    
-    # Define dist with parameters from the distribution of Fig. 4b in 
-    # M.K. Ochi, J.E. Wahlen, Prediction of severest significant wave height, 
+    """
+
+    # Define dist with parameters from the distribution of Fig. 4b in
+    # M.K. Ochi, J.E. Wahlen, Prediction of severest significant wave height,
     # Coast. Eng. Chap. 36 (1980) pp. 587-599.
-    
+
     dist = GeneralizedGammaDistribution(1.60, 0.98, 1.37)
 
     # CDF(0.5) should be roughly 0.21, see Fig. 4b
@@ -168,13 +168,13 @@ def test_generalized_gamma_reproduce_Ochi_CDF():
     # CDF(4) should be roughly 0.98, see Fig. 4b
     # CDF(6) should be roughly 0.995, see Fig. 4b
 
-    p1= dist.cdf(0.5)
-    p2= dist.cdf(1)
-    p3= dist.cdf(1.5)
-    p4= dist.cdf(2)
-    p5= dist.cdf(4)
-    p6= dist.cdf(6)
-    
+    p1 = dist.cdf(0.5)
+    p2 = dist.cdf(1)
+    p3 = dist.cdf(1.5)
+    p4 = dist.cdf(2)
+    p5 = dist.cdf(4)
+    p6 = dist.cdf(6)
+
     np.testing.assert_allclose(p1, 0.21, atol=0.05)
     np.testing.assert_allclose(p2, 0.55, atol=0.05)
     np.testing.assert_allclose(p3, 0.70, atol=0.05)
@@ -185,101 +185,117 @@ def test_generalized_gamma_reproduce_Ochi_CDF():
     # CDF(negative value) should be 0
     p = dist.cdf(-1)
     assert p == 0
-   
-    
+
+
 def test_generalized_gamma_compare_scipy_to_virocon_PDF():
     """
     Test which compares the PDF of a fitted scipy distribution and compare it 
     to the PDF of a fitted virocon distribution. The results should be the 
     same since virocon uses scipy.
 
-    """  
-    
+    """
+
     x = np.linspace(2, 15, num=100)
-    
-    # Create sample 
+
+    # Create sample
     true_m = 5
     true_c = 2.42
     true_loc = 0
-    true_lambda_= 0.5
-    gamma_samples = sts.gengamma.rvs( a=true_m, c=true_c, loc=true_loc, scale=1/true_lambda_, size=100, random_state=42)
-    
+    true_lambda_ = 0.5
+    gamma_samples = sts.gengamma.rvs(
+        a=true_m,
+        c=true_c,
+        loc=true_loc,
+        scale=1 / true_lambda_,
+        size=100,
+        random_state=42,
+    )
+
     # Fit distribution with virocon
     my_gamma = GeneralizedGammaDistribution()
     my_gamma.fit(gamma_samples, method="mle")
     my_pdf = my_gamma.pdf(x)
-    
+
     # Fit distribution with scipy
     ref_gamma = sts.gengamma.fit(gamma_samples, floc=0)
-    ref_pdf = sts.gengamma.pdf(x, ref_gamma[0], ref_gamma[1], ref_gamma[2], ref_gamma[3])
-    
-    # Compare results 
+    ref_pdf = sts.gengamma.pdf(
+        x, ref_gamma[0], ref_gamma[1], ref_gamma[2], ref_gamma[3]
+    )
+
+    # Compare results
     for i in range(len(ref_pdf)):
         np.testing.assert_almost_equal(my_pdf[i], ref_pdf[i])
-        
-    
+
+
 def test_generalized_gamma_compare_scipy_to_virocon_ICDF():
     """
     Test which compares the ICDF of a fitted scipy distribution and compare it 
     to the ICDF of a fitted virocon distribution. The results should be the 
     same since virocon uses scipy.
 
-    """  
-    
+    """
+
     p = np.linspace(0.01, 0.99, num=100)
-    
-    # Create sample 
+
+    # Create sample
     true_m = 5
     true_c = 2.42
     true_loc = 0
-    true_lambda_= 0.5
-    gamma_samples = sts.gengamma.rvs( a=true_m, c=true_c, loc=true_loc, scale=1/true_lambda_, size=100, random_state=42)
-    
+    true_lambda_ = 0.5
+    gamma_samples = sts.gengamma.rvs(
+        a=true_m,
+        c=true_c,
+        loc=true_loc,
+        scale=1 / true_lambda_,
+        size=100,
+        random_state=42,
+    )
+
     # Fit distribution with virocon
     my_gamma = GeneralizedGammaDistribution()
     my_gamma.fit(gamma_samples, method="mle")
     my_icdf = my_gamma.icdf(p)
-    
+
     # Fit distribution with scipy
     ref_gamma = sts.gengamma.fit(gamma_samples, floc=0)
-    ref_icdf = sts.gengamma.ppf(p, ref_gamma[0], ref_gamma[1], ref_gamma[2], ref_gamma[3])
-    
-    # Compare results 
+    ref_icdf = sts.gengamma.ppf(
+        p, ref_gamma[0], ref_gamma[1], ref_gamma[2], ref_gamma[3]
+    )
+
+    # Compare results
     for i in range(len(ref_icdf)):
         np.testing.assert_almost_equal(my_icdf[i], ref_icdf[i])
- 
-    
+
+
 def test_generalized_gamma_compare_scipy_fit_to_virocon_fit():
     """
     Test comparing the fitting of scipy to the fit of virocon. The results
     should be the same since virocon uses scipy.
 
-    """ 
-    
-    # Create sample 
+    """
+
+    # Create sample
     true_m = 5
     true_c = 2.42
     true_loc = 0
-    true_lambda_= 0.5
-    gamma_samples = sts.gengamma.rvs( a=true_m, c=true_c, loc=true_loc, scale=1/true_lambda_, size=100, random_state=42)
+    true_lambda_ = 0.5
+    gamma_samples = sts.gengamma.rvs(
+        a=true_m,
+        c=true_c,
+        loc=true_loc,
+        scale=1 / true_lambda_,
+        size=100,
+        random_state=42,
+    )
 
     # Fit distribution with virocon
     my_gamma = GeneralizedGammaDistribution()
     my_gamma.fit(gamma_samples, method="mle")
-    
+
     # Fit distribution with scipy
     ref_gamma = sts.gengamma.fit(gamma_samples, floc=0)
-    
-    # Compare results 
+
+    # Compare results
     assert my_gamma.m == ref_gamma[0]
     assert my_gamma.c == ref_gamma[1]
     assert my_gamma._scale == ref_gamma[3]
-    
-    
-    
-    
-    
-    
-    
-    
-    

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -156,9 +156,10 @@ def test_generalized_gamma_reproduce_Ochi_CDF():
     """
 
     # Define dist with parameters from the distribution of Fig. 4b in
-    # M.K. Ochi, J.E. Wahlen, Prediction of severest significant wave height,
-    # Coast. Eng. Chap. 36 (1980) pp. 587-599.
-
+    # M.K. Ochi, J.E. Wahlen, New approach for estimating the severes
+    # sea state from statistical data , Coast. Eng. Chapter 38 (1992) 
+    # pp. 512-525.
+    
     dist = GeneralizedGammaDistribution(1.60, 0.98, 1.37)
 
     # CDF(0.5) should be roughly 0.21, see Fig. 4b

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -149,7 +149,7 @@ def test_fit_exponentiated_weibull_with_zero():
 
 def test_generalized_gamma_reproduce_Ochi_CDF():
     """
-    Test reproducing the fitting of Ochi et. al (1992) and compare it to
+    Test reproducing the fitting of Ochi (1992) and compare it to
     virocons implementation of the generalized gamma distribution. The results
     should be the same.
 

--- a/virocon/distributions.py
+++ b/virocon/distributions.py
@@ -1225,8 +1225,9 @@ class GeneralizedGammaDistribution(Distribution):
 
     References
     ----------
-    .. [5] M.K. Ochi, J.E. Wahlen, Prediction of severest significant wave 
-        height, Coast. Eng. Chap. 36 (1980) pp. 587-599.
+    .. [5] M.K. Ochi, J.E. Wahlen, New approach for estimating the severes
+        sea state from statistical data , Coast. Eng. Chapter 38 (1992) 
+        pp. 512-525.
         
     """
 

--- a/virocon/distributions.py
+++ b/virocon/distributions.py
@@ -1225,8 +1225,8 @@ class GeneralizedGammaDistribution(Distribution):
 
     References
     ----------
-    .. [5] M.K. Ochi, J.E. Wahlen, New approach for estimating the severes
-        sea state from statistical data , Coast. Eng. Chapter 38 (1992) 
+    .. [5] M.K. Ochi, New approach for estimating the severest sea state from 
+        statistical data , Coast. Eng. Chapter 38 (1992) 
         pp. 512-525.
         
     """

--- a/virocon/distributions.py
+++ b/virocon/distributions.py
@@ -1228,7 +1228,7 @@ class GammaDistribution(Distribution):
     """
 
     def __init__(
-        self, alpha=1, beta=1, loc=0, scale=1, f_alpha=None, f_beta=None, f_delta=None, f_scale=None
+        self, alpha=1, beta=1, loc=0, scale=1, f_alpha=None, f_beta=None, f_loc=None, f_scale=None
     ):
 
         # TODO set parameters to fixed values if provided
@@ -1238,7 +1238,8 @@ class GammaDistribution(Distribution):
         self.scale = scale  # location
         self.f_alpha = f_alpha
         self.f_beta = f_beta
-        self.f_delta = f_delta
+        self.f_loc = f_loc
+        self.f_scale= f_scale
 
 
     @property
@@ -1255,7 +1256,7 @@ class GammaDistribution(Distribution):
             loc = self.loc
         if scale is None:
             scale = self.scale
-        return beta, loc, alpha, scale  # shape2, location, shape1, scale
+        return alpha, beta, loc, scale  # shape1, shape2, location, scale
     
 
 
@@ -1337,15 +1338,15 @@ class GammaDistribution(Distribution):
         p0 = {"alpha": self.alpha, "beta": self.beta, "loc": self.loc, "scale":self.scale}
 
         fparams = {}
+        if self.f_alpha is not None:
+            fparams["fshape1"] = self.f_alpha
         if self.f_beta is not None:
             fparams["fshape2"] = self.f_beta
         if self.f_loc is not None:
             fparams["floc"] = self.f_loc
         if self.f_scale is not None:
             fparams["fscale"] = self.f_scale
-        if self.f_alpha is not None:
-            fparams["fshape1"] = self.f_alpha
-
+     
         self.beta, self.loc, self.alpha = sts.gengamma.fit(
             sample, p0["alpha"], p0["beta"], loc=p0["loc"], scale=p0["scale"], **fparams
         )

--- a/virocon/distributions.py
+++ b/virocon/distributions.py
@@ -1191,77 +1191,88 @@ class GeneralizedGammaDistribution(Distribution):
     """
     A generalized Gamma distribution. 
    
-    The distributions probability density function is given by [1]_ :
+    The distributions probability density function is given by [3]_ , [5]_ and 
+    [6]_ . The parametrization is orientated on [3]_ :
     
-    :math:`f(x, \\alpha, \\beta) = \\frac{|\\beta|x^{\\beta\\alpha-1} exp(-x^{\\beta}) }{\\Gamma(\\alpha)}`
+    :math:`f(x) = \\frac{k(x-a)^{kc-1} exp \\left[ - \\left( \\frac{(x-a)^{k}} {b} \\right) \\right] }{b^{kc}\\Gamma(c)}`
     
     Parameters
     ----------
-    alpha : float
+    c : float
         Shape parameter of the generalized Gamma distribution. Defaults to 1.
-    beta : float
+    k : float
         Second shape parameter of the generalized Gamma distribution. Defaults
         to 1.
-    loc : float
+    a : float
         Additional location parameter of the generalized Gamma distribution 
         (3-parameter generalized Gamma distribution). Defaults to 0.
-    scale : float
+    b : float
         Additional scale parameter of the generalized Gamma distribution 
         (3-parameter generalized Gamma distribution). Defaults to 1.
-    f_alpha : float
+    f_c : float
         Fixed shape parameter of the generalized Gamma distribution (e.g. 
-        given physical parameter). If this parameter is set, alpha is ignored. 
+        given physical parameter). If this parameter is set, c is ignored. 
         Defaults to None.
-    f_beta : float
+    f_k : float
        Fixed second shape parameter of the generalized Gamma distribution (e.g.
-       given  physical parameter). If this parameter is set, beta is ignored. 
+       given  physical parameter). If this parameter is set, k is ignored. 
        Defaults to None. 
-    f_loc : float
+    f_a : float
         Fixed location parameter of the generalized Gamma distribution (e.g. 
-        given physical parameter). If this parameter is set, deta is ignored. 
+        given physical parameter). If this parameter is set, a is ignored. 
+        Defaults to None.
+    f_b : float
+        Fixed scale parameter of the generalized Gamma distribution (e.g. 
+        given physical parameter). If this parameter is set, b is ignored. 
         Defaults to None.
 
     References
     ----------
-    .. [1] E.W. Stacy, “A Generalization of the Gamma Distribution”, Annals of 
+    .. [3] Forbes, C.; Evans, M.; Hastings, N; Peacock, B. (2011)
+        Statistical Distributions, 4th Edition, Published by 
+        John Wiley & Sons, Inc., Hoboken, New Jersey., 
+        Page 143
+    .. [5] E.W. Stacy, “A Generalization of the Gamma Distribution”, Annals of 
         Mathematical Statistics, Vol 33(3), pp. 1187–1192.
+    .. [6] M.K. Ochi, J.E. Wahlen, Prediction of severest significant wave 
+        height, Coast. Eng. Chap. 36 (1980) 587e599.
         
     """
 
     def __init__(
-        self, alpha=1, beta=1, loc=0, scale=1, f_alpha=None, f_beta=None, f_loc=None, f_scale=None
+        self, c=1, k=1, a=0, b=1, f_c=None, f_k=None, f_a=0, f_b=None
     ):
 
         # TODO set parameters to fixed values if provided
-        self.alpha = alpha  # shape
-        self.beta = beta  # shape
-        self.loc = loc  # location
-        self.scale = scale  # location
-        self.f_alpha = f_alpha
-        self.f_beta = f_beta
-        self.f_loc = f_loc
-        self.f_scale= f_scale
+        self.c = c  # shape
+        self.k = k  # shape
+        self.a = a # location
+        self.b = b  # location
+        self.f_c = f_c
+        self.f_k = f_k
+        self.f_a = f_a
+        self.f_b= f_b
 
 
     @property
     def parameters(self):
-        return {"alpha": self.alpha, "beta": self.beta, "loc": self.loc, "scale":self.scale}
+        return {"c": self.c, "k": self.k, "a": self.a, "b":self.b}
     
 
-    def _get_scipy_parameters(self, alpha, beta, loc, scale):
-        if alpha is None:
-            alpha = self.alpha
-        if beta is None:
-            beta = self.beta
-        if loc is None:
-            loc = self.loc
-        if scale is None:
-            scale = self.scale
-        return alpha, beta, loc, scale  # shape1, shape2, location, scale
+    def _get_scipy_parameters(self, c, k, a, b):
+        if c is None:
+            c= self.c
+        if k is None:
+            k = self.k
+        if a is None:
+            a= self.a
+        if b is None:
+            b = self.b
+        return c, k, a, b  # shape1, shape2, location, scale
     
 
 
-    def cdf(self, x, alpha=None, beta=None, loc=None, scale=None):
+    def cdf(self, x, c=None, k=None, a=0, b=None):
         """
         Cumulative distribution function.
         
@@ -1271,20 +1282,20 @@ class GeneralizedGammaDistribution(Distribution):
             Points at which the cdf is evaluated.
             Shape: 1-dimensional.
         alpha : float, optional
-            The shape parameter. Defaults to self.alpha.
+            The shape parameter. Defaults to self.c.
         beta : float, optional
-            The second shape parameter. Defaults to self.beta.
+            The second shape parameter. Defaults to self.k.
         loc: float, optional
-            The additional location parameter . Defaults to self.loc.
+            The additional location parameter . Defaults to self.a.
         scale: float, optional
-            The additional scale parameter . Defaults to self.scale.
+            The additional scale parameter . Defaults to self.b.
         
         """
 
-        scipy_par = self._get_scipy_parameters(alpha, beta, loc, scale)
+        scipy_par = self._get_scipy_parameters(c, k, a, b)
         return sts.gengamma.cdf(x, *scipy_par)
 
-    def icdf(self, prob, alpha=None, beta=None, loc=None, scale=None):
+    def icdf(self, prob, c=None, k=None, a=0, b=None):
         """
         Inverse cumulative distribution function.
         
@@ -1293,21 +1304,21 @@ class GeneralizedGammaDistribution(Distribution):
         prob : array_like
             Probabilities for which the i_cdf is evaluated.
             Shape: 1-dimensional
-        alpha : float, optional
-            The shape parameter. Defaults to self.alpha.
-        beta : float, optional
-            The second shape parameter. Defaults to self.beta.
-        loc: float, optional
-            The additional location parameter . Defaults to self.loc.
-        scale: float, optional
-            The additional scale parameter . Defaults to self.scale.
+        c : float, optional
+            The shape parameter. Defaults to self.c.
+        k : float, optional
+            The second shape parameter. Defaults to self.k.
+        a: float, optional
+            The additional location parameter . Defaults to self.a.
+        b: float, optional
+            The additional scale parameter . Defaults to self.b.
         
         """
 
-        scipy_par = self._get_scipy_parameters(alpha, beta, loc, scale)
+        scipy_par = self._get_scipy_parameters(c, k, a, b)
         return sts.gengamma.ppf(prob, *scipy_par)
 
-    def pdf(self, x, alpha=None, beta=None, loc=None, scale=None):
+    def pdf(self, x, c=None, k=None, a=0, b=None):
         """
         Probability density function.
         
@@ -1316,40 +1327,40 @@ class GeneralizedGammaDistribution(Distribution):
         x : array_like, 
             Points at which the pdf is evaluated.
             Shape: 1-dimensional.
-        alpha_ : float, optional
-            The shape parameter. Defaults to self.alpha.
-        beta : float, optional
-            The second shape parameter. Defaults to self.beta.
-        loc: float, optional
-            The additional location parameter . Defaults to self.loc.
-        scale: float, optional
-            The additional scale parameter . Defaults to self.scale.
+        c : float, optional
+            The shape parameter. Defaults to self.c.
+        k : float, optional
+            The second shape parameter. Defaults to self.k.
+        a: float, optional
+            The additional location parameter . Defaults to self.a.
+        b: float, optional
+            The additional scale parameter . Defaults to self.b.
         
         """
 
-        scipy_par = self._get_scipy_parameters(alpha, beta, loc, scale)
+        scipy_par = self._get_scipy_parameters(c, k, a, b)
         return sts.gengamma.pdf(x, *scipy_par)
 
-    def draw_sample(self, n, alpha=None, beta=None, loc=None, scale=None):
-        scipy_par = self._get_scipy_parameters(alpha, beta, loc, scale)
+    def draw_sample(self, n, c=None, k=None, a=0, b=None):
+        scipy_par = self._get_scipy_parameters(c, k, a, b)
         rvs_size = self._get_rvs_size(n, scipy_par)
         return sts.gengamma.rvs(*scipy_par, size=rvs_size)
 
     def _fit_mle(self, sample):
-        p0 = {"alpha": self.alpha, "beta": self.beta, "loc": self.loc, "scale":self.scale}
+        p0 = {"c": self.c, "k": self.k, "a": self.a, "b":self.b}
 
         fparams = {}
-        if self.f_alpha is not None:
-            fparams["fshape1"] = self.f_alpha
-        if self.f_beta is not None:
-            fparams["fshape2"] = self.f_beta
-        if self.f_loc is not None:
-            fparams["floc"] = self.f_loc
-        if self.f_scale is not None:
-            fparams["fscale"] = self.f_scale
+        if self.f_c is not None:
+            fparams["fshape1"] = self.c
+        if self.f_k is not None:
+            fparams["fshape2"] = self.f_k
+        if self.f_a is not None:
+            fparams["floc"] = self.f_a
+        if self.f_b is not None:
+            fparams["fscale"] = self.f_b
      
-        self.beta, self.loc, self.alpha = sts.gengamma.fit(
-            sample, p0["alpha"], p0["beta"], loc=p0["loc"], scale=p0["scale"], **fparams
+        self.c, self.k, self.a, self.b = sts.gengamma.fit(
+            sample, p0["c"], p0["k"], loc=p0["a"], scale=p0["b"], **fparams
         )
 
     def _fit_lsq(self, data, weights):

--- a/virocon/distributions.py
+++ b/virocon/distributions.py
@@ -56,7 +56,8 @@ class ConditionalDistribution:
     conditional_parameters : dict
         Dictionary of dependence functions for conditional parameters. Parameter names as keys.
     fixed_parameters : dict
-        Values of the fixed parameters. Parameters as keys.
+        Values of the fixed parameters. The fixed parameters do not change, 
+        even when fitting them. Parameters as keys.
     distributions_per_interval : list
         Instances of distribution fitted to intervals
     parameters_per_interval : list of dict
@@ -463,16 +464,16 @@ class WeibullDistribution(Distribution):
         distribution). Defaults to 0.
     f_alpha : float
         Fixed scale parameter of the weibull distribution (e.g. given physical
-        parameter). If this parameter is set, lambda is ignored. Defaults to 
-        None.
+        parameter). If this parameter is set, lambda is ignored. The fixed 
+        parameter does not change, even when fitting it. Defaults to None.
     f_beta : float
        Fixed shape parameter of the weibull distribution (e.g. given physical
-       parameter). If this parameter is set, k is ignored. Defaults to 
-       None. 
+       parameter). If this parameter is set, k is ignored. The fixed parameter 
+       does not change, even when fitting it. Defaults to None. 
     f_gamma : float
         Fixed location parameter of the weibull distribution (e.g. given physical
-        parameter). If this parameter is set, theta is ignored. Defaults to 
-        None.
+        parameter). If this parameter is set, theta is ignored. The fixed 
+        parameter does not change, even when fitting it. Defaults to None.
 
     References
     ----------
@@ -613,12 +614,12 @@ class LogNormalDistribution(Distribution):
         Defaults to 1.
     f_mu : float
         Fixed parameter mu of the lognormal distribution (e.g. given physical
-        parameter). If this parameter is set, mu is ignored. Defaults to 
-        None.
+        parameter). If this parameter is set, mu is ignored. The fixed 
+        parameter does not change, even when fitting it. Defaults to None.
     f_sigma : float
        Fixed parameter sigma of the lognormal distribution (e.g. given 
-       physical parameter). If this parameter is set, sigma is ignored. 
-       Defaults to None
+       physical parameter). If this parameter is set, sigma is ignored. The
+       fixed parameter does not change, even when fitting it. Defaults to None.
     
     References
     ----------
@@ -757,12 +758,12 @@ class NormalDistribution(Distribution):
         Defaults to 1.
     f_mu : float
         Fixed parameter mu of the normal distribution (e.g. given physical
-        parameter). If this parameter is set, mu is ignored. Defaults to 
-        None.
+        parameter). If this parameter is set, mu is ignored. The fixed 
+        parameter does not change, even when fitting it. Defaults to None.
     f_sigma : float
        Fixed parameter sigma of the normal distribution (e.g. given 
        physical parameter). If this parameter is set, sigma is ignored. 
-       Defaults to None
+       Defaults to None.
     
     References
     ----------
@@ -889,11 +890,12 @@ class LogNormalNormFitDistribution(LogNormalDistribution):
         Defaults to 1.
     f_mu : float
         Fixed parameter mu of the lognormal distribution (e.g. given physical
-        parameter). If this parameter is set, mu is ignored. Defaults to 
-        None.
+        parameter). If this parameter is set, mu is ignored. The fixed 
+        parameter does not change, even when fitting it. Defaults to None.
     f_sigma : float
        Fixed parameter sigma of the lognormal distribution (e.g. given 
-       physical parameter). If this parameter is set, sigma is ignored. 
+       physical parameter). If this parameter is set, sigma is ignored. The
+       fixed parameter does not change, even when fitting it.
        Defaults to None. 
     
     """
@@ -998,16 +1000,16 @@ class ExponentiatedWeibullDistribution(Distribution):
         Defaults to 1.
     f_alpha : float
         Fixed alpha parameter of the weibull distribution (e.g. given physical
-        parameter). If this parameter is set, alpha is ignored. Defaults to 
-        None.
+        parameter). If this parameter is set, alpha is ignored. The fixed 
+        parameter does not change, even when fitting it. Defaults to None.
     f_beta : float
        Fixed beta parameter of the weibull distribution (e.g. given physical
-       parameter). If this parameter is set, beta is ignored. Defaults to 
-       None. 
+       parameter). If this parameter is set, beta is ignored. The fixed 
+       parameter does not change, even when fitting it. Defaults to None. 
     f_delta : float
         Fixed delta parameter of the weibull distribution (e.g. given physical
-        parameter). If this parameter is set, delta is ignored. Defaults to 
-        None.
+        parameter). If this parameter is set, delta is ignored. The fixed 
+        parameter does not change, even when fitting it. Defaults to None.
 
     References
     ----------
@@ -1189,9 +1191,8 @@ class ExponentiatedWeibullDistribution(Distribution):
 
 class GeneralizedGammaDistribution(Distribution):
     """
-    A generalized Gamma distribution. 
+    A 4-parameter generalized Gamma distribution. 
    
-    The distributions probability density function is given by [5]_ . 
     The parametrization is orientated on [5]_ :
     
     :math:`f(x) = \\frac{ \\lambda^{cm} cx^{cm-1} \\exp \\left[ - \\left(\\lambda x^{c} \\right) \\right] }{\\Gamma(m)}`
@@ -1199,25 +1200,28 @@ class GeneralizedGammaDistribution(Distribution):
     Parameters
     ----------
     m : float
-        Shape parameter of the generalized Gamma distribution. Defaults to 1.
+        First shape parameter of the generalized Gamma distribution. Defaults to 1.
     c : float
         Second shape parameter of the generalized Gamma distribution. Defaults
         to 1.
     lambda_ : float
-        Additional scale parameter of the generalized Gamma distribution 
-        (3-parameter generalized Gamma distribution). Defaults to 1.
+        Scale parameter of the generalized Gamma distribution. 
+        Defaults to 1.
     f_m : float
         Fixed shape parameter of the generalized Gamma distribution (e.g. 
-        given physical parameter). If this parameter is set, c is ignored. 
+        given physical parameter). If this parameter is set, m is ignored. The
+        fixed parameter does not change, even when fitting it.
         Defaults to None.
     f_c : float
        Fixed second shape parameter of the generalized Gamma distribution (e.g.
-       given  physical parameter). If this parameter is set, k is ignored. 
+       given  physical parameter). If this parameter is set, c is ignored. The
+       fixed parameter does not change, even when fitting it.
        Defaults to None. 
     f_lambda_ : float
-        Fixed scale parameter of the generalized Gamma distribution (e.g. 
-        given physical parameter). If this parameter is set, b is ignored. 
-        Defaults to None.
+        Fixed reciprocal scale parameter of the generalized Gamma distribution (e.g. 
+        given physical parameter). If this parameter is set, lambda_ is ignored. 
+        The fixed parameter does not change, even when fitting it.Defaults to 
+        None.
 
     References
     ----------
@@ -1231,14 +1235,14 @@ class GeneralizedGammaDistribution(Distribution):
         # TODO set parameters to fixed values if provided
         self.m = m  # shape
         self.c = c  # shape
-        self.lambda_ = lambda_  # scale
+        self.lambda_ = lambda_  # reciprocal scale
         self.f_m = f_m
         self.f_c = f_c
         self.f_lambda_ = f_lambda_
 
     @property
     def parameters(self):
-        return {"m": self.m, "c": self.c, "lambda": self.lambda_}
+        return {"m": self.m, "c": self.c, "lambda_": self.lambda_}
 
     @property
     def _scale(self):
@@ -1257,7 +1261,7 @@ class GeneralizedGammaDistribution(Distribution):
             scipy_scale = self._scale
         else:
             scipy_scale = 1 / lambda_
-        return m, c, 0, scipy_scale  # shape1, shape2, location=0, scale
+        return m, c, 0, scipy_scale  # shape1, shape2, location=0, reciprocal scale
 
     def cdf(self, x, m=None, c=None, lambda_=None):
         """
@@ -1269,11 +1273,11 @@ class GeneralizedGammaDistribution(Distribution):
             Points at which the cdf is evaluated.
             Shape: 1-dimensional.
         m : float, optional
-            The shape parameter. Defaults to self.m.
+            First shape parameter. Defaults to self.m.
         c : float, optional
             The second shape parameter. Defaults to self.c.
         lambda_: float, optional
-            The additional scale parameter . Defaults to self.lambda_.
+            The reciprocal scale parameter . Defaults to self.lambda_.
         
         """
 
@@ -1290,11 +1294,11 @@ class GeneralizedGammaDistribution(Distribution):
             Probabilities for which the i_cdf is evaluated.
             Shape: 1-dimensional
         m : float, optional
-            The shape parameter. Defaults to self.m.
+            First shape parameter. Defaults to self.m.
         c : float, optional
             The second shape parameter. Defaults to self.c.
         lambda_: float, optional
-            The additional scale parameter . Defaults to self.lambda_.
+            The reciprocal scale parameter . Defaults to self.lambda_.
         
         """
 
@@ -1311,11 +1315,11 @@ class GeneralizedGammaDistribution(Distribution):
             Points at which the pdf is evaluated.
             Shape: 1-dimensional.
         m : float, optional
-            The shape parameter. Defaults to self.m.
+            First shape parameter. Defaults to self.m.
         c : float, optional
             The second shape parameter. Defaults to self.k.
         lambda_: float, optional
-            The additional scale parameter . Defaults to self.lambda_.
+            The reciprocal scale parameter . Defaults to self.lambda_.
         
         """
 

--- a/virocon/distributions.py
+++ b/virocon/distributions.py
@@ -1243,17 +1243,17 @@ class GeneralizedGammaDistribution(Distribution):
     def parameters(self):
         return {"m": self.m, "c": self.c, "lambda":self._lambda}
  
-# HIER NOCH KORRIGIEREN
+# TODO: Check that this is correct
 
     @property
     def _scale(self):
-        return np.exp(self.mu)
+        return (self._lambda)^(-1)
 
     @_scale.setter
     def _scale(self, val):
-        self.mu = np.log(val)
+        self._lambda = (val)^(-1)
  
-# HIER NOCH KORRIGIEREN
+# TODO: Check that this is correct
 
     def _get_scipy_parameters(self, m, c, _lambda):
         if m is None:
@@ -1263,7 +1263,7 @@ class GeneralizedGammaDistribution(Distribution):
         if _lambda is None:
             _lambda = self._lambda
         else:
-            _lamdba = np.exp(_lambda)
+            _lamdba = (_lambda)^(-1)
         return m, c, 0,  _lambda  # shape1, shape2, scale
     
 

--- a/virocon/distributions.py
+++ b/virocon/distributions.py
@@ -1247,11 +1247,11 @@ class GeneralizedGammaDistribution(Distribution):
 
     @property
     def _scale(self):
-        return (self._lambda)^(-1)
+        return 1/(self._lambda)
 
     @_scale.setter
     def _scale(self, val):
-        self._lambda = (val)^(-1)
+        self._lambda = 1/val
  
 # TODO: Check that this is correct
 
@@ -1261,10 +1261,10 @@ class GeneralizedGammaDistribution(Distribution):
         if c is None:
             c = self.c
         if _lambda is None:
-            _lambda = self._lambda
+            scale = self._scale
         else:
-            _lamdba = (_lambda)^(-1)
-        return m, c, 0,  _lambda  # shape1, shape2, scale
+            scale = 1/(_lambda)
+        return m, c, 0,  scale  # shape1, shape2, location=0, scale
     
 
 
@@ -1339,16 +1339,16 @@ class GeneralizedGammaDistribution(Distribution):
     def _fit_mle(self, sample):
         p0 = {"m": self.m, "c": self.c, "lambda":self._lambda}
 
-        fparams = {}
+        fparams = {"floc": 0}
         if self.f_m is not None:
-            fparams["fshape1"] = self.m
+            fparams["fshape1"] = self.f_m
         if self.f_c is not None:
             fparams["fshape2"] = self.f_c
         if self.f_lambda is not None:
-            fparams["fscale"] = self.f_lambda
+            fparams["fscale"] = 1/(self.f_lambda)
      
-        self.m, self.c, self.b = sts.gengamma.fit(
-            sample, p0["m"], p0["c"], loc=0, scale=p0["lambda"], **fparams
+        self.m, self.c, _, self._lambda = sts.gengamma.fit(
+            sample, p0["m"], p0["c"], scale=p0["lambda"], **fparams
         )
 
     def _fit_lsq(self, data, weights):

--- a/virocon/distributions.py
+++ b/virocon/distributions.py
@@ -1290,7 +1290,7 @@ class GammaDistribution(Distribution):
         """
 
         scipy_par = self._get_scipy_parameters(alpha, beta, delta)
-        return sts.genextreme.cdf(x, *scipy_par)
+        return sts.gamma.cdf(x, *scipy_par)
 
     def icdf(self, prob, alpha=None, beta=None, delta=None):
         """
@@ -1311,7 +1311,7 @@ class GammaDistribution(Distribution):
         """
 
         scipy_par = self._get_scipy_parameters(alpha, beta, delta)
-        return sts.genextreme.ppf(prob, *scipy_par)
+        return sts.gamma.ppf(prob, *scipy_par)
 
     def pdf(self, x, alpha=None, beta=None, delta=None):
         """
@@ -1332,12 +1332,12 @@ class GammaDistribution(Distribution):
         """
 
         scipy_par = self._get_scipy_parameters(alpha, beta, delta)
-        return sts.genextreme.pdf(x, *scipy_par)
+        return sts.gamma.pdf(x, *scipy_par)
 
     def draw_sample(self, n, alpha=None, beta=None, delta=None):
         scipy_par = self._get_scipy_parameters(alpha, beta, delta)
         rvs_size = self._get_rvs_size(n, scipy_par)
-        return sts.genextreme.rvs(*scipy_par, size=rvs_size)
+        return sts.gamma.rvs(*scipy_par, size=rvs_size)
 
     def _fit_mle(self, sample):
         p0 = {"alpha": self.alpha, "beta": self.beta, "delta": self.delta}
@@ -1350,7 +1350,7 @@ class GammaDistribution(Distribution):
         if self.f_alpha is not None:
             fparams["fscale"] = self.f_alpha
 
-        self.beta, self.delta, self.alpha = sts.genextreme.fit(
+        self.beta, self.delta, self.alpha = sts.gamma.fit(
             sample, p0["beta"], loc=p0["delta"], scale=p0["alpha"], **fparams
         )
 

--- a/virocon/distributions.py
+++ b/virocon/distributions.py
@@ -1243,17 +1243,6 @@ class GeneralizedGammaDistribution(Distribution):
     def parameters(self):
         return {"m": self.m, "c": self.c, "lambda":self._lambda}
  
-# TODO: Check that this is correct
-
-    @property
-    def _scale(self):
-        return 1/(self._lambda)
-
-    @_scale.setter
-    def _scale(self, val):
-        self._lambda = 1/val
- 
-# TODO: Check that this is correct
 
     def _get_scipy_parameters(self, m, c, _lambda):
         if m is None:
@@ -1261,10 +1250,10 @@ class GeneralizedGammaDistribution(Distribution):
         if c is None:
             c = self.c
         if _lambda is None:
-            scale = self._scale
+            scipy_scale= 1/(self._lambda)
         else:
-            scale = 1/(_lambda)
-        return m, c, 0,  scale  # shape1, shape2, location=0, scale
+            scipy_scale= 1/_lambda
+        return m, c, 0,  scipy_scale  # shape1, shape2, location=0, scale
     
 
 
@@ -1346,7 +1335,9 @@ class GeneralizedGammaDistribution(Distribution):
             fparams["fshape2"] = self.f_c
         if self.f_lambda is not None:
             fparams["fscale"] = 1/(self.f_lambda)
-     
+            
+ # location parameter muss 0 sein
+    
         self.m, self.c, _, self._lambda = sts.gengamma.fit(
             sample, p0["m"], p0["c"], scale=p0["lambda"], **fparams
         )

--- a/virocon/distributions.py
+++ b/virocon/distributions.py
@@ -1226,7 +1226,7 @@ class GeneralizedGammaDistribution(Distribution):
     References
     ----------
     .. [5] M.K. Ochi, J.E. Wahlen, Prediction of severest significant wave 
-        height, Coast. Eng. Chap. 36 (1980) 587e599.
+        height, Coast. Eng. Chap. 36 (1980) pp. 587-599.
         
     """
 

--- a/virocon/distributions.py
+++ b/virocon/distributions.py
@@ -16,6 +16,7 @@ __all__ = [
     "LogNormalDistribution",
     "NormalDistribution",
     "ExponentiatedWeibullDistribution",
+    "GeneralizedGammaDistribution"
 ]
 
 # The distributions parameters need to have an order, this order is defined by
@@ -1186,7 +1187,7 @@ class ExponentiatedWeibullDistribution(Distribution):
         return wlsq_error
 
 
-class GammaDistribution(Distribution):
+class GeneralizedGammaDistribution(Distribution):
     """
     A generalized Gamma distribution. 
    


### PR DESCRIPTION
With this pull request, the generalized gamma distribution after Ochi et. al (1992) [1] should be implemented in Virocon's distributions. This distribution has been used in latest research by Haselsteiner et. Al (2020) [2].

[1] Ochi, M. K. (1992). New approach for estimating the severest sea state. 23rd International Conference on Coastal Engineering, 512–525. https://doi.org/10.1061/9780872629332.038
[2] A.F. Haselsteiner, K.-D. Thoben, Predicting wave heights for marine design by prioritizing extreme events in a global model, Renewable Energy 156 (2020) pp. 1146- 1157