### PR TITLE
Fix issues introduced by new versions of matplotlib and scipy

### DIFF
--- a/virocon/plotting.py
+++ b/virocon/plotting.py
@@ -21,7 +21,7 @@ __all__ = [
     "plot_2D_contour",
 ]
 
-# colors (schemes) choosen according to https://personal.sron.nl/~pault/
+# colors (schemes) chosen according to https://personal.sron.nl/~pault/
 
 
 def _rainbow_PuRd():
@@ -147,7 +147,7 @@ def plot_marginal_quantiles(model, sample, semantics=None, axes=None):
         dist_wrapper = MarginalDistWrapper(model, dim)
         ax = axes[dim]
 
-        sts.probplot(sample[:, dim], dist=dist_wrapper, fit=False, plot=ax)
+        sts.probplot(sample[:, dim], dist=dist_wrapper, fit=True, plot=ax)
         ax.get_lines()[0].set_markerfacecolor("k")
         ax.get_lines()[0].set_markeredgecolor("k")
         ax.get_lines()[0].set_marker("x")

--- a/virocon/plotting.py
+++ b/virocon/plotting.py
@@ -296,11 +296,11 @@ def plot_2D_isodensity(
     swap_axis : boolean, optional
         If True the second dimension of the model is plotted on the x-axis and
         the first on the y-axis. Otherwise vice-versa. Defaults to False.
-    limits = list of tuples, optional
+    limits : list of tuples, optional
         Specifies in which rectangular region the density is calculated and 
         plotted. If None (default) limits will be set automatically.
         Example: [(0, 20), (0, 12)]
-    levels = list of floats, optional
+    levels : list of floats, optional
         The probability density levels that are plotted. If None (default)
         levels are set automatically.
         Example: [0.001, 0.01, 0.1]
@@ -384,8 +384,9 @@ def plot_2D_isodensity(
     cmap = _rainbow_PuRd()
     colors = cmap(np.linspace(0, 1, num=n_levels))
     CS = ax.contour(X, Y, Z, levels=levels, colors=colors)
+    proxies = [plt.Line2D([], [], color=pc.get_edgecolor()[0]) for pc in CS.collections]
     ax.legend(
-        CS.collections,
+        proxies,
         lvl_labels,
         loc="upper left",
         ncol=1,


### PR DESCRIPTION
There where API changes with matplotlib=3.5.0 and scipy=1.7.0 that caused issues with virocons plotting module.
See issues #141 and #147 for more details.
