### PR TITLE
Fix black failing

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,6 +63,7 @@ project = "virocon"
 copyright = "2021, virocon"
 author = "virocon developers"
 
+
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.

--- a/examples/3D_contour.py
+++ b/examples/3D_contour.py
@@ -33,6 +33,7 @@ data.index = pd.to_datetime(data.pop(data.columns[0]), format="%Y-%m-%d-%H")
 # univariate parametric distributions and the dependence structure.
 # The dependence structure is defined using parametric functions.
 
+
 # A 3-parameter power function, which will be used as a dependence function.
 def _power3(x, a, b, c):
     return a + b * x**c

--- a/examples/hstz_contour_detailed.py
+++ b/examples/hstz_contour_detailed.py
@@ -46,6 +46,7 @@ data = read_ec_benchmark_dataset("datasets/ec-benchmark_dataset_A.txt")
 # univariate parametric distributions and the dependence structure.
 # The dependence structure is defined using parametric functions.
 
+
 # A 3-parameter power function, which will be used as a dependence function.
 def _power3(x, a, b, c):
     return a + b * x**c

--- a/manual_tests/manual_test_IFORM.py
+++ b/manual_tests/manual_test_IFORM.py
@@ -14,6 +14,7 @@ from virocon import (
 
 x = np.linspace((0, 0), (10, 10), num=100)
 
+
 # Logarithmic square function.
 def _lnsquare2(x, a=3.62, b=5.77):
     return np.log(a + b * np.sqrt(x / 9.81))

--- a/manual_tests/manual_test_ISORM.py
+++ b/manual_tests/manual_test_ISORM.py
@@ -13,6 +13,7 @@ from virocon import (
 
 x = np.linspace((0, 0), (10, 10), num=100)
 
+
 # Logarithmic square function.
 def _lnsquare2(x, a=3.62, b=5.77):
     return np.log(a + b * np.sqrt(x / 9.81))

--- a/manual_tests/manual_test_WES4.py
+++ b/manual_tests/manual_test_WES4.py
@@ -57,7 +57,6 @@ sigma_data_key = "sigma"
 
 class MyIntervalSlicer(WidthOfIntervalSlicer):
     def _slice(self, data):
-
         interval_slices, interval_references, interval_boundaries = super()._slice(data)
 
         # discard slices below 4 m/s

--- a/manual_tests/manual_test_design_conditions.py
+++ b/manual_tests/manual_test_design_conditions.py
@@ -16,6 +16,7 @@ from virocon.utils import calculate_design_conditions
 
 data = pd.read_csv("datasets/NDBC_buoy_46025.csv", sep=",")[["Hs", "T"]]
 
+
 # A 3-parameter power function (a dependence function).
 def _power3(x, a, b, c):
     return a + b * x**c

--- a/manual_tests/manual_test_marginals.py
+++ b/manual_tests/manual_test_marginals.py
@@ -14,6 +14,7 @@ from virocon import (
 
 # %%
 
+
 # Logarithmic square function.
 def _lnsquare2(x, a=3.62, b=5.77):
     return np.log(a + b * np.sqrt(x / 9.81))

--- a/manual_tests/manual_test_printing.py
+++ b/manual_tests/manual_test_printing.py
@@ -21,12 +21,14 @@ from virocon import (
 # def _logistics4(x, a, b, c, d):
 #     return a + b / (1 + np.exp(-1 * np.abs(c) * (x - d)))
 
+
 # A 4-parameter logististics function (a dependence function).
 def _logistics4(x, a=1, b=1, c=-1, d=1):
     return a + b / (1 + np.exp(c * (x - d)))
 
 
 # _logistics4 = lambda x, a, b, c=-1, d=1 : a + b / (1 + np.exp(c * (x - d)))
+
 
 # A 3-parameter function designed for the scale parameter (alpha) of an
 # exponentiated Weibull distribution with shape2=5 (see 'Global hierarchical

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 alabaster==0.7.12
 attrs==21.4.0
 Babel==2.9.1
-black==22.1.0
+black==23.3
 certifi==2022.12.7
 charset-normalizer==2.0.12
 click==8.0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ matplotlib==3.5.1
 mypy-extensions==0.4.3
 networkx==2.6
 numpy==1.22.2
-packaging==21.3
+packaging==23.1
 pandas==1.4.1
 pathspec==0.9.0
 Pillow==9.3.0

--- a/tests/comparison-to-virocon-v1/test_contours.py
+++ b/tests/comparison-to-virocon-v1/test_contours.py
@@ -52,7 +52,6 @@ def reference_data_DSContour():
 
 
 def test_IFORM(reference_coordinates_IFORM):
-
     # Logarithmic square function.
     def _lnsquare2(x, a=3.62, b=5.77):
         return np.log(a + b * np.sqrt(x / 9.81))
@@ -89,7 +88,6 @@ def test_IFORM(reference_coordinates_IFORM):
 
 
 def test_ISORM(reference_coordinates_ISORM):
-
     # Logarithmic square function.
     def _lnsquare2(x, a=3.62, b=5.77):
         return np.log(a + b * np.sqrt(x / 9.81))
@@ -158,7 +156,6 @@ def test_HDC(reference_coordinates_HDC):
 
 
 def test_DirectSamplingContour(reference_data_DSContour):
-
     sample = reference_data_DSContour["sample"]
     ref_coordinates = reference_data_DSContour["ref_coordinates"]
 

--- a/tests/comparison-to-virocon-v1/test_workflows.py
+++ b/tests/comparison-to-virocon-v1/test_workflows.py
@@ -309,7 +309,6 @@ def test_WES4(dataset_wes_sigmau, refdata_wes_sigmau):
 
     class MyIntervalSlicer(WidthOfIntervalSlicer):
         def _slice(self, data):
-
             interval_slices, interval_references, interval_boundaries = super()._slice(
                 data
             )

--- a/virocon/_fitting.py
+++ b/virocon/_fitting.py
@@ -34,7 +34,7 @@ def fit_function(func, x, y, p0, method, bounds, weights=None):
 def convert_bounds_for_curve_fit(bounds):
     lower_bounds = []
     upper_bounds = []
-    for (lower, upper) in bounds:
+    for lower, upper in bounds:
         lower_bounds.append(lower if lower is not None else -np.inf)
         upper_bounds.append(upper if upper is not None else np.inf)
     return [lower_bounds, upper_bounds]

--- a/virocon/_nsphere.py
+++ b/virocon/_nsphere.py
@@ -87,7 +87,6 @@ class NSphere:
         max_iters = max([10, int(10000 / self.n_samples)])
 
         for iteration in range(1, max_iters):
-
             # Tau controls the step size of the optimization. With each iteration
             # a smaller step is chosen. 3 is an empirical value.
             tau = 3 / iteration
@@ -219,7 +218,6 @@ class NSphere:
 
 
 if __name__ == "__main__":
-
     #    sphere = NSphere(3, 1000)
     #
     #    samples = sphere.unit_sphere_points

--- a/virocon/contours.py
+++ b/virocon/contours.py
@@ -395,7 +395,6 @@ class HighestDensityContour(Contour):
     """
 
     def __init__(self, model, alpha, limits=None, deltas=None):
-
         self.model = model
         self.alpha = alpha
         self.limits = limits

--- a/virocon/dependencies.py
+++ b/virocon/dependencies.py
@@ -9,6 +9,7 @@ from virocon._fitting import fit_function, fit_constrained_function
 
 __all__ = ["DependenceFunction"]
 
+
 # TODO test that order of execution does not matter
 # it should not matter if the dependent or the conditioner are fitted first
 class DependenceFunction:

--- a/virocon/distributions.py
+++ b/virocon/distributions.py
@@ -352,7 +352,6 @@ class Distribution(ABC):
     @property
     @abstractmethod
     def parameters(self):
-
         """
         Parameters of the probability distribution.
 
@@ -629,7 +628,6 @@ class LogNormalDistribution(Distribution):
     """
 
     def __init__(self, mu=0, sigma=1, f_mu=None, f_sigma=None):
-
         self.mu = mu if f_mu is None else f_mu
         self.sigma = sigma if f_sigma is None else f_sigma  # shape
         self.f_mu = f_mu
@@ -773,7 +771,6 @@ class NormalDistribution(Distribution):
     """
 
     def __init__(self, mu=0, sigma=1, f_mu=None, f_sigma=None):
-
         self.mu = mu if f_mu is None else f_mu  # location
         self.sigma = sigma if f_sigma is None else f_sigma  # scale
         self.f_mu = f_mu
@@ -900,7 +897,6 @@ class LogNormalNormFitDistribution(LogNormalDistribution):
     """
 
     def __init__(self, mu_norm=0, sigma_norm=1, f_mu_norm=None, f_sigma_norm=None):
-
         self.mu_norm = mu_norm if f_mu_norm is None else f_mu_norm
         self.sigma_norm = sigma_norm if f_sigma_norm is None else f_sigma_norm
         self.f_mu_norm = f_mu_norm
@@ -961,7 +957,6 @@ class LogNormalNormFitDistribution(LogNormalDistribution):
         return sts.lognorm.rvs(*scipy_par, size=rvs_size)
 
     def _fit_mle(self, sample):
-
         if self.f_mu_norm is None:
             self.mu_norm = np.mean(sample)
         else:
@@ -1149,7 +1144,6 @@ class ExponentiatedWeibullDistribution(Distribution):
 
     @staticmethod
     def _estimate_alpha_beta(delta, x, p, w, falpha=None, fbeta=None):
-
         # As x = 0 causes problems when x_star is calculated, zero-elements
         # are not considered in the parameter estimation.
         indices = np.nonzero(x)
@@ -1175,7 +1169,6 @@ class ExponentiatedWeibullDistribution(Distribution):
 
     @staticmethod
     def _wlsq_error(delta, x, p, w, return_alpha_beta=False, falpha=None, fbeta=None):
-
         # As x = 0 causes problems when x_star is calculated, zero-elements
         # are not considered in the parameter estimation.
         indices = np.nonzero(x)
@@ -1237,7 +1230,6 @@ class GeneralizedGammaDistribution(Distribution):
     """
 
     def __init__(self, m=1, c=1, lambda_=1, f_m=None, f_c=None, f_lambda_=None):
-
         self.m = m if f_m is None else f_m  # shape
         self.c = c if f_c is None else f_c  # shape
         self.lambda_ = lambda_ if f_lambda_ is None else f_lambda_  # reciprocal scale
@@ -1397,7 +1389,6 @@ class VonMisesDistribution(Distribution):
     """
 
     def __init__(self, kappa=1, mu=0, f_kappa=None, f_mu=None):
-
         self.kappa = kappa  # shpae
         self.mu = mu  # location
         self.f_kappa = f_kappa

--- a/virocon/intervals.py
+++ b/virocon/intervals.py
@@ -149,7 +149,6 @@ class WidthOfIntervalSlicer(IntervalSlicer):
         self.value_range = value_range
 
     def _slice(self, data):
-
         if self.value_range is None:
             data_min = 0
             data_max = np.max(data)

--- a/virocon/jointmodels.py
+++ b/virocon/jointmodels.py
@@ -408,7 +408,6 @@ class GlobalHierarchicalModel(MultivariateModel):
 
         p = np.empty(len(x))
         for i in range(len(x)):
-
             integration_limits = [
                 (lower_integration_limits[j], x[i, j]) for j in range(n_dim)
             ]
@@ -475,7 +474,6 @@ class GlobalHierarchicalModel(MultivariateModel):
         return f
 
     def marginal_cdf(self, x, dim):
-
         """
         Marginal cumulative distribution function.
 
@@ -535,7 +533,6 @@ class GlobalHierarchicalModel(MultivariateModel):
         return F
 
     def marginal_icdf(self, p, dim, precision_factor=1):
-
         """
         Marginal inverse cumulative distribution function.
 

--- a/virocon/plotting.py
+++ b/virocon/plotting.py
@@ -140,7 +140,6 @@ def plot_marginal_quantiles(model, sample, semantics=None, axes=None):
             self.idx = idx
 
         def ppf(self, q):
-
             return self.model.marginal_icdf(q, self.idx)
 
     for dim in range(n_dim):

--- a/virocon/predefined.py
+++ b/virocon/predefined.py
@@ -45,6 +45,7 @@ def get_DNVGL_Hs_Tz():
         conditions and environmental loads.
 
     """
+
     # TODO docstrings with links to literature
     # DNVGL 3.6.3
     def _power3(x, a, b, c):

--- a/virocon/utils.py
+++ b/virocon/utils.py
@@ -48,7 +48,6 @@ def read_ec_benchmark_dataset(file_path=None):
 
 
 def calculate_design_conditions(contour, steps=None, swap_axis=False):
-
     if swap_axis:
         x_idx = 1
         y_idx = 0
@@ -79,7 +78,6 @@ def calculate_design_conditions(contour, steps=None, swap_axis=False):
     frontier_y = []
 
     for x2 in zip(steps, steps):
-
         x, y = intersection(x1, y1, x2, y2)
         assert len(x) <= 2
         assert len(y) <= 2


### PR DESCRIPTION
Fixes #174 

`black` was updated, and they introduced new formatting rules.

I downloaded the version that our GitHub action currently uses (23.3) and used it to autoformat our code.
I changed our requirements.txt such that `black 23.3` is used from now on. GitHub action will continue to use the newest stable release such that we can run into this issue again.

Updating `black `required me to update `packaging`.

I also needed to autoformat some of the manual test files that we want to get rid of (see #7) suggesting we should get this cleaning done 🧹 