### PR TITLE
Fix design condition bug and add unit tests

### DIFF
--- a/tests/test_intersection.py
+++ b/tests/test_intersection.py
@@ -2,6 +2,7 @@ import numpy as np
 
 from virocon._intersection import intersection
 
+
 def test_intersection():
     x = np.linspace(1, 5, 11)
     y1 = 0 * x + 1

--- a/tests/test_intersection.py
+++ b/tests/test_intersection.py
@@ -1,1 +1,14 @@
-import pytest
+import numpy as np
+
+from virocon._intersection import intersection
+
+def test_intersection():
+    x = np.linspace(1, 5, 11)
+    y1 = 0 * x + 1
+    y2 = 0.5 * x
+
+    # The curves intersect at point (2, 1).
+    ix, iy = intersection(x, y1, x, y2)
+
+    np.testing.assert_allclose(ix, 2, atol=0.001)
+    np.testing.assert_allclose(iy, 1, atol=0.001)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,11 +5,52 @@ import numpy as np
 
 from pathlib import Path
 
+from virocon import (
+    DependenceFunction,
+    WeibullDistribution,
+    LogNormalDistribution,
+    GlobalHierarchicalModel,
+    IFORMContour
+)
+
 from virocon.utils import (
     read_ec_benchmark_dataset,
     ROOT_DIR,
     sort_points_to_form_continuous_line,
+    calculate_design_conditions
 )
+
+
+@pytest.fixture(scope="module")
+def seastate_model():
+    """
+    This joint distribution model described by Vanem and Bitner-Gregersen (2012)
+    is widely used in academia. Here, we use it for evaluation.
+    DOI: 10.1016/j.apor.2012.05.006
+    """
+
+    def _power3(x, a=0.1000, b=1.489, c=0.1901):
+        return a + b * x**c
+
+    # A 3-parameter exponential function (a dependence function).
+    def _exp3(x, a=0.0400, b=0.1748, c=-0.2243):
+        return a + b * np.exp(c * x)
+
+    bounds = [(0, None), (0, None), (None, None)]
+    power3 = DependenceFunction(_power3, bounds)
+    exp3 = DependenceFunction(_exp3, bounds)
+
+    dist_description_0 = {
+        "distribution": WeibullDistribution(alpha=2.776, beta=1.471, gamma=0.8888),
+    }
+    dist_description_1 = {
+        "distribution": LogNormalDistribution(),
+        "conditional_on": 0,
+        "parameters": {"mu": power3, "sigma": exp3},
+    }
+    model = GlobalHierarchicalModel([dist_description_0, dist_description_1])
+
+    return model
 
 
 def test_read_ec_benchmark_dataset():
@@ -22,6 +63,28 @@ def test_read_ec_benchmark_dataset():
     assert isinstance(data.index, pd.DatetimeIndex)
     assert len(data) == 82805
 
+
+def test_calculate_design_conditions(seastate_model):
+    # Test design condition calculation with  the IFORM contour presented in
+    # Haselsteiner et al. (2017; DOI: 10.1016/j.coastaleng.2017.03.002 .
+    alpha = 1 / (25 * 365.25 * 24/3)
+    contour = IFORMContour(seastate_model, alpha)
+
+    design_conditions = calculate_design_conditions(contour, steps=None, swap_axis=False)
+    assert design_conditions.shape == (10, 2)
+    np.testing.assert_allclose(design_conditions[1], [2.5, 11.6], atol=0.5)
+    np.testing.assert_allclose(design_conditions[9], [15.2, 13.4], atol=0.5)
+
+    steps = 20
+    design_conditions = calculate_design_conditions(contour, steps=steps, swap_axis=False)
+    assert design_conditions.shape == (steps, 2)
+    np.testing.assert_allclose(design_conditions[1], [1.6, 10.9], atol=0.5)
+    np.testing.assert_allclose(design_conditions[19], [15.2, 13.4], atol=0.5)
+
+    design_conditions = calculate_design_conditions(contour, steps=steps, swap_axis=True)
+    assert design_conditions.shape == (steps, 2)
+    np.testing.assert_allclose(design_conditions[0], [2.6, 1.1], atol=0.5)
+    np.testing.assert_allclose(design_conditions[19], [13.9, 14.1], atol=0.5)
 
 def test_sort_points_to_form_continuous_line():
     phi = np.linspace(0, 1.8 * np.pi, num=10, endpoint=False)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,14 +10,14 @@ from virocon import (
     WeibullDistribution,
     LogNormalDistribution,
     GlobalHierarchicalModel,
-    IFORMContour
+    IFORMContour,
 )
 
 from virocon.utils import (
     read_ec_benchmark_dataset,
     ROOT_DIR,
     sort_points_to_form_continuous_line,
-    calculate_design_conditions
+    calculate_design_conditions,
 )
 
 
@@ -67,24 +67,31 @@ def test_read_ec_benchmark_dataset():
 def test_calculate_design_conditions(seastate_model):
     # Test design condition calculation with  the IFORM contour presented in
     # Haselsteiner et al. (2017; DOI: 10.1016/j.coastaleng.2017.03.002 .
-    alpha = 1 / (25 * 365.25 * 24/3)
+    alpha = 1 / (25 * 365.25 * 24 / 3)
     contour = IFORMContour(seastate_model, alpha)
 
-    design_conditions = calculate_design_conditions(contour, steps=None, swap_axis=False)
+    design_conditions = calculate_design_conditions(
+        contour, steps=None, swap_axis=False
+    )
     assert design_conditions.shape == (10, 2)
     np.testing.assert_allclose(design_conditions[1], [2.5, 11.6], atol=0.5)
     np.testing.assert_allclose(design_conditions[9], [15.2, 13.4], atol=0.5)
 
     steps = 20
-    design_conditions = calculate_design_conditions(contour, steps=steps, swap_axis=False)
+    design_conditions = calculate_design_conditions(
+        contour, steps=steps, swap_axis=False
+    )
     assert design_conditions.shape == (steps, 2)
     np.testing.assert_allclose(design_conditions[1], [1.6, 10.9], atol=0.5)
     np.testing.assert_allclose(design_conditions[19], [15.2, 13.4], atol=0.5)
 
-    design_conditions = calculate_design_conditions(contour, steps=steps, swap_axis=True)
+    design_conditions = calculate_design_conditions(
+        contour, steps=steps, swap_axis=True
+    )
     assert design_conditions.shape == (steps, 2)
     np.testing.assert_allclose(design_conditions[0], [2.6, 1.1], atol=0.5)
     np.testing.assert_allclose(design_conditions[19], [13.9, 14.1], atol=0.5)
+
 
 def test_sort_points_to_form_continuous_line():
     phi = np.linspace(0, 1.8 * np.pi, num=10, endpoint=False)

--- a/virocon/utils.py
+++ b/virocon/utils.py
@@ -49,7 +49,9 @@ def read_ec_benchmark_dataset(file_path=None):
     return data
 
 
-def calculate_design_conditions(contour, steps: Union[list, int] = None, swap_axis=False) -> npt.ArrayLike:
+def calculate_design_conditions(
+    contour, steps: Union[list, int] = None, swap_axis=False
+) -> npt.ArrayLike:
     """Calculates design conditions (relevant points for structural analysis) for a contour.
 
     For example, in a sea state contour, one is interested in the upper Hs part for
@@ -80,16 +82,22 @@ def calculate_design_conditions(contour, steps: Union[list, int] = None, swap_ax
     # Define the x-positions where a design condition will be calculated
     # The y-values will be found by calculating the intersections between
     # vertical lines and the contour coordinates.
-    small_spacer = 0.0001 * (np.max(x1) - np.min(x1)) # Required to ensure that conditions on limits are picked up.
+    small_spacer = 0.0001 * (
+        np.max(x1) - np.min(x1)
+    )  # Required to ensure that conditions on limits are picked up.
     default_lower_limit = np.min(x1) + small_spacer
     default_uppper_limit = np.max(x1) - small_spacer
     if steps is None:
-        steps = np.linspace(default_lower_limit, default_uppper_limit, endpoint=True, num=10)
+        steps = np.linspace(
+            default_lower_limit, default_uppper_limit, endpoint=True, num=10
+        )
     else:
         try:
             iter(steps)  # if steps is iterable use it
         except TypeError:  # if steps is not iterable assume it's an int
-            steps = np.linspace(default_lower_limit, default_uppper_limit, endpoint=True, num=steps)
+            steps = np.linspace(
+                default_lower_limit, default_uppper_limit, endpoint=True, num=steps
+            )
 
     # Vertical line ylimits.
     y2 = [np.min(y1) - np.max(y1) * 0.1, np.max(y1) + np.max(y1) * 0.1]

--- a/virocon/utils.py
+++ b/virocon/utils.py
@@ -79,8 +79,8 @@ def calculate_design_conditions(contour, steps: Union[list, int] = None, swap_ax
 
     # Define the x-positions where a design condition will be calculated
     # The y value will be found by calculating the intersection between
-    # a vetical line and the contour coordinates.
-    small_spacer = 0.0001 * (np.max(x1) - np.min(x1))
+    # a vertical line and the contour coordinates.
+    small_spacer = 0.0001 * (np.max(x1) - np.min(x1)) # Required to ensure that conditions on limits are picked up.
     default_lower_limit = np.min(x1) + small_spacer
     default_uppper_limit = np.max(x1) - small_spacer
     if steps is None:

--- a/virocon/utils.py
+++ b/virocon/utils.py
@@ -78,8 +78,8 @@ def calculate_design_conditions(contour, steps: Union[list, int] = None, swap_ax
     y1 = np.append(coords[:, y_idx], coords[0, y_idx])
 
     # Define the x-positions where a design condition will be calculated
-    # The y value will be found by calculating the intersection between
-    # a vertical line and the contour coordinates.
+    # The y-values will be found by calculating the intersections between
+    # vertical lines and the contour coordinates.
     small_spacer = 0.0001 * (np.max(x1) - np.min(x1)) # Required to ensure that conditions on limits are picked up.
     default_lower_limit = np.min(x1) + small_spacer
     default_uppper_limit = np.max(x1) - small_spacer


### PR DESCRIPTION
Fixes #194 

Improves test coverage (#99)

Sometimes `calculate_design_conditions` did not pick up a design condition on the very limit.

To avoid this I added a spacer:
```
    # Define the x-positions where a design condition will be calculated
    # The y-values will be found by calculating the intersections between
    # vertical lines and the contour coordinates.
    small_spacer = 0.0001 * (np.max(x1) - np.min(x1)) # Required to ensure that conditions on limits are picked up.
    default_lower_limit = np.min(x1) + small_spacer
    default_uppper_limit = np.max(x1) - small_spacer
```