### PR TITLE
Add Method of Moment fit

### DIFF
--- a/tests/test_predefined.py
+++ b/tests/test_predefined.py
@@ -33,7 +33,7 @@ def test_DNVGL_Hs_Tz():
     # Compare with the results from contours presented in Haselsteiner et al. (2019),
     # https://doi.org/10.1115/OMAE2019-96523
     # Highest Hs value is ca. 5 m, highest Tz value is ca. 16.2 s.
-    np.testing.assert_allclose(max(coords[:, 0]), 5, atol=1.5)
+    np.testing.assert_allclose(max(coords[:, 0]), 10, atol=1.5)
     np.testing.assert_allclose(max(coords[:, 1]), 16.2, atol=2)
 
 

--- a/tests/test_predefined.py
+++ b/tests/test_predefined.py
@@ -30,11 +30,10 @@ def test_DNVGL_Hs_Tz():
     contour = IFORMContour(model, alpha)
     coords = contour.coordinates
 
-    # Compare with the results from contours presented in Haselsteiner et al. (2019),
-    # https://doi.org/10.1115/OMAE2019-96523
-    # Highest Hs value is ca. 5 m, highest Tz value is ca. 16.2 s.
+    # The highest Hs value is ca. 10 m and the highest Tz value is ca. 17 s,
+    # see https://github.com/virocon-organization/virocon/pull/228/files#r2007155949
     np.testing.assert_allclose(max(coords[:, 0]), 10, atol=1.5)
-    np.testing.assert_allclose(max(coords[:, 1]), 16.2, atol=2)
+    np.testing.assert_allclose(max(coords[:, 1]), 17, atol=2)
 
 
 def test_DNVGL_Hs_U():

--- a/virocon/distributions.py
+++ b/virocon/distributions.py
@@ -10,6 +10,7 @@ import scipy.stats as sts
 
 from abc import ABC, abstractmethod
 from scipy.optimize import fmin
+from scipy.signal import find_peaks
 
 __all__ = [
     "WeibullDistribution",
@@ -415,8 +416,8 @@ class Distribution(ABC):
             Valid options for str are: 'linear', 'quadratic', 'cubic'.
         """
 
-        if method.lower() == "mle":
-            self._fit_mle(data)
+        if method.lower() == "mle" or method.lower() == "mm":
+            self._fit_mle(data,method)
         elif method.lower() == "lsq" or method.lower() == "wlsq":
             self._fit_lsq(data, weights)
         else:
@@ -427,7 +428,7 @@ class Distribution(ABC):
             )
 
     @abstractmethod
-    def _fit_mle(self, data):
+    def _fit_mle(self, data, method='MLE'):
         """Fit the distribution using maximum likelihood estimation."""
 
     @abstractmethod
@@ -584,10 +585,10 @@ class WeibullDistribution(Distribution):
         rvs_size = self._get_rvs_size(n, scipy_par)
         return sts.weibull_min.rvs(*scipy_par, size=rvs_size, random_state=random_state)
 
-    def _fit_mle(self, sample):
+    def _fit_mle(self, sample, method='MLE'):
         p0 = {"alpha": self.alpha, "beta": self.beta, "gamma": self.gamma}
 
-        fparams = {}
+        fparams = {'method':method}
         if self.f_beta is not None:
             fparams["f0"] = self.f_beta
         if self.f_gamma is not None:
@@ -726,10 +727,10 @@ class LogNormalDistribution(Distribution):
         rvs_size = self._get_rvs_size(n, scipy_par)
         return sts.lognorm.rvs(*scipy_par, size=rvs_size, random_state=random_state)
 
-    def _fit_mle(self, sample):
+    def _fit_mle(self, sample, method='MLE'):
         p0 = {"scale": self._scale, "sigma": self.sigma}
 
-        fparams = {"floc": 0}
+        fparams = {"floc": 0, 'method':method}
 
         if self.f_sigma is not None:
             fparams["f0"] = self.f_sigma
@@ -859,10 +860,10 @@ class NormalDistribution(Distribution):
         rvs_size = self._get_rvs_size(n, scipy_par)
         return sts.norm.rvs(*scipy_par, size=rvs_size, random_state=random_state)
 
-    def _fit_mle(self, sample):
+    def _fit_mle(self, sample, method='MLE'):
         p0 = {"loc": self.mu, "scale": self.sigma}
 
-        fparams = {}
+        fparams = {'method':method}
 
         if self.f_mu is not None:
             fparams["floc"] = self.f_mu
@@ -966,7 +967,7 @@ class LogNormalNormFitDistribution(LogNormalDistribution):
         rvs_size = self._get_rvs_size(n, scipy_par)
         return sts.lognorm.rvs(*scipy_par, size=rvs_size, random_state=random_state)
 
-    def _fit_mle(self, sample):
+    def _fit_mle(self, sample, method='MLE'):
         if self.f_mu_norm is None:
             self.mu_norm = np.mean(sample)
         else:
@@ -1078,10 +1079,10 @@ class ExponentiatedWeibullDistribution(Distribution):
         rvs_size = self._get_rvs_size(n, scipy_par)
         return sts.exponweib.rvs(*scipy_par, size=rvs_size, random_state=random_state)
 
-    def _fit_mle(self, sample):
+    def _fit_mle(self, sample, method='MLE'):
         p0 = {"alpha": self.alpha, "beta": self.beta, "delta": self.delta}
 
-        fparams = {"floc": 0}
+        fparams = {"floc": 0, "method":method}
 
         if self.f_delta is not None:
             fparams["f0"] = self.f_delta
@@ -1338,10 +1339,10 @@ class GeneralizedGammaDistribution(Distribution):
         rvs_size = self._get_rvs_size(n, scipy_par)
         return sts.gengamma.rvs(*scipy_par, size=rvs_size, random_state=random_state)
 
-    def _fit_mle(self, sample):
+    def _fit_mle(self, sample, method='MLE'):
         p0 = {"m": self.m, "c": self.c, "scale": self._scale}
 
-        fparams = {"floc": 0}
+        fparams = {"floc": 0, "method":method}
 
         if self.f_m is not None:
             fparams["fshape1"] = self.f_m

--- a/virocon/distributions.py
+++ b/virocon/distributions.py
@@ -416,7 +416,7 @@ class Distribution(ABC):
         """
 
         if method.lower() == "mle" or method.lower() == "mm":
-            self._fit_mle(data,method)
+            self._fit_mle(data, method)
         elif method.lower() == "lsq" or method.lower() == "wlsq":
             self._fit_lsq(data, weights)
         else:
@@ -427,7 +427,7 @@ class Distribution(ABC):
             )
 
     @abstractmethod
-    def _fit_mle(self, data, method='MLE'):
+    def _fit_mle(self, data, method="MLE"):
         """Fit the distribution using maximum likelihood estimation."""
 
     @abstractmethod
@@ -584,10 +584,10 @@ class WeibullDistribution(Distribution):
         rvs_size = self._get_rvs_size(n, scipy_par)
         return sts.weibull_min.rvs(*scipy_par, size=rvs_size, random_state=random_state)
 
-    def _fit_mle(self, sample, method='MLE'):
+    def _fit_mle(self, sample, method="MLE"):
         p0 = {"alpha": self.alpha, "beta": self.beta, "gamma": self.gamma}
 
-        fparams = {'method':method}
+        fparams = {"method": method}
         if self.f_beta is not None:
             fparams["f0"] = self.f_beta
         if self.f_gamma is not None:
@@ -726,10 +726,10 @@ class LogNormalDistribution(Distribution):
         rvs_size = self._get_rvs_size(n, scipy_par)
         return sts.lognorm.rvs(*scipy_par, size=rvs_size, random_state=random_state)
 
-    def _fit_mle(self, sample, method='MLE'):
+    def _fit_mle(self, sample, method="MLE"):
         p0 = {"scale": self._scale, "sigma": self.sigma}
 
-        fparams = {"floc": 0, 'method':method}
+        fparams = {"floc": 0, "method": method}
 
         if self.f_sigma is not None:
             fparams["f0"] = self.f_sigma
@@ -859,10 +859,10 @@ class NormalDistribution(Distribution):
         rvs_size = self._get_rvs_size(n, scipy_par)
         return sts.norm.rvs(*scipy_par, size=rvs_size, random_state=random_state)
 
-    def _fit_mle(self, sample, method='MLE'):
+    def _fit_mle(self, sample, method="MLE"):
         p0 = {"loc": self.mu, "scale": self.sigma}
 
-        fparams = {'method':method}
+        fparams = {"method": method}
 
         if self.f_mu is not None:
             fparams["floc"] = self.f_mu
@@ -966,7 +966,7 @@ class LogNormalNormFitDistribution(LogNormalDistribution):
         rvs_size = self._get_rvs_size(n, scipy_par)
         return sts.lognorm.rvs(*scipy_par, size=rvs_size, random_state=random_state)
 
-    def _fit_mle(self, sample, method='MLE'):
+    def _fit_mle(self, sample, method="MLE"):
         if self.f_mu_norm is None:
             self.mu_norm = np.mean(sample)
         else:
@@ -1078,10 +1078,10 @@ class ExponentiatedWeibullDistribution(Distribution):
         rvs_size = self._get_rvs_size(n, scipy_par)
         return sts.exponweib.rvs(*scipy_par, size=rvs_size, random_state=random_state)
 
-    def _fit_mle(self, sample, method='MLE'):
+    def _fit_mle(self, sample, method="MLE"):
         p0 = {"alpha": self.alpha, "beta": self.beta, "delta": self.delta}
 
-        fparams = {"floc": 0, "method":method}
+        fparams = {"floc": 0, "method": method}
 
         if self.f_delta is not None:
             fparams["f0"] = self.f_delta
@@ -1338,10 +1338,10 @@ class GeneralizedGammaDistribution(Distribution):
         rvs_size = self._get_rvs_size(n, scipy_par)
         return sts.gengamma.rvs(*scipy_par, size=rvs_size, random_state=random_state)
 
-    def _fit_mle(self, sample, method='MLE'):
+    def _fit_mle(self, sample, method="MLE"):
         p0 = {"m": self.m, "c": self.c, "scale": self._scale}
 
-        fparams = {"floc": 0, "method":method}
+        fparams = {"floc": 0, "method": method}
 
         if self.f_m is not None:
             fparams["fshape1"] = self.f_m
@@ -1477,10 +1477,10 @@ class VonMisesDistribution(Distribution):
         rvs_size = self._get_rvs_size(n, scipy_par)
         return sts.vonmises.rvs(*scipy_par, size=rvs_size, random_state=random_state)
 
-    def _fit_mle(self, sample, method='MLE'):
+    def _fit_mle(self, sample, method="MLE"):
         p0 = {"shape": self.kappa, "loc": self.mu}
 
-        fparams = {"fscale": 1, "method":method}
+        fparams = {"fscale": 1, "method": method}
 
         if self.f_mu is not None:
             fparams["floc"] = self.f_mu
@@ -1611,13 +1611,13 @@ class ScipyDistribution(Distribution):
         rvs_size = self._get_rvs_size(n, scipy_par)
         return self.scipy_dist.rvs(*scipy_par, size=rvs_size, random_state=random_state)
 
-    def _fit_mle(self, sample, method='MLE'):
+    def _fit_mle(self, sample, method="MLE"):
         # Split initial parameter values into positional shape parameters and loc and scale.
         p0 = [v for k, v in self.parameters.items() if k != "loc" and k != "scale"]
         loc0 = self.parameters.get("loc", 0)
         scale0 = self.parameters.get("scale", 1)
 
-        fparams = {'method':method}
+        fparams = {"method": method}
         for par_name in self._param_names:
             val = getattr(self, f"f_{par_name}")
             if val is not None:

--- a/virocon/distributions.py
+++ b/virocon/distributions.py
@@ -999,6 +999,8 @@ class LogNormalNormFitDistribution(LogNormalDistribution):
         return sts.lognorm.rvs(*scipy_par, size=rvs_size, random_state=random_state)
 
     def _fit_mom(self, sample):
+        # We need to have a _fit_mom definition here as otherwise the 
+        # the LogNormalDistribution's _fit_mom method would be called.
         raise NotImplementedError()
 
     def _fit_mle(self, sample):

--- a/virocon/distributions.py
+++ b/virocon/distributions.py
@@ -999,8 +999,7 @@ class LogNormalNormFitDistribution(LogNormalDistribution):
         return sts.lognorm.rvs(*scipy_par, size=rvs_size, random_state=random_state)
 
     def _fit_mom(self, sample):
-        # We need to have a _fit_mom definition here as otherwise the 
-        # the LogNormalDistribution's _fit_mom method would be called.
+        # This is needed to avoid calling the corresponding implementation of the parent class.
         raise NotImplementedError()
 
     def _fit_mle(self, sample):

--- a/virocon/distributions.py
+++ b/virocon/distributions.py
@@ -10,7 +10,6 @@ import scipy.stats as sts
 
 from abc import ABC, abstractmethod
 from scipy.optimize import fmin
-from scipy.signal import find_peaks
 
 __all__ = [
     "WeibullDistribution",
@@ -1478,10 +1477,10 @@ class VonMisesDistribution(Distribution):
         rvs_size = self._get_rvs_size(n, scipy_par)
         return sts.vonmises.rvs(*scipy_par, size=rvs_size, random_state=random_state)
 
-    def _fit_mle(self, sample):
+    def _fit_mle(self, sample, method='MLE'):
         p0 = {"shape": self.kappa, "loc": self.mu}
 
-        fparams = {"fscale": 1}
+        fparams = {"fscale": 1, "method":method}
 
         if self.f_mu is not None:
             fparams["floc"] = self.f_mu
@@ -1612,13 +1611,13 @@ class ScipyDistribution(Distribution):
         rvs_size = self._get_rvs_size(n, scipy_par)
         return self.scipy_dist.rvs(*scipy_par, size=rvs_size, random_state=random_state)
 
-    def _fit_mle(self, sample):
+    def _fit_mle(self, sample, method='MLE'):
         # Split initial parameter values into positional shape parameters and loc and scale.
         p0 = [v for k, v in self.parameters.items() if k != "loc" and k != "scale"]
         loc0 = self.parameters.get("loc", 0)
         scale0 = self.parameters.get("scale", 1)
 
-        fparams = {}
+        fparams = {'method':method}
         for par_name in self._param_names:
             val = getattr(self, f"f_{par_name}")
             if val is not None:

--- a/virocon/predefined.py
+++ b/virocon/predefined.py
@@ -64,7 +64,9 @@ def get_DNVGL_Hs_Tz():
 
     dist_description_hs = {
         "distribution": WeibullDistribution(),
-        "intervals": WidthOfIntervalSlicer(width=0.5),
+        "intervals": WidthOfIntervalSlicer(
+            width=0.5
+        ),  # 0.5 m is a common choice, see e.g. 10.1115/OMAE2020-18041
     }
 
     dist_description_tz = {

--- a/virocon/predefined.py
+++ b/virocon/predefined.py
@@ -75,7 +75,7 @@ def get_DNVGL_Hs_Tz():
 
     dist_descriptions = [dist_description_hs, dist_description_tz]
 
-    fit_descriptions = [{'method':'MM','weights':None},None]
+    fit_descriptions = [{"method": "MM", "weights": None}, None]
 
     semantics = {
         "names": ["Significant wave height", "Zero-up-crossing period"],
@@ -501,4 +501,3 @@ def get_Nonzero_EW_Hs_S():
     }
 
     return dist_descriptions, fit_descriptions, semantics, transformations
-

--- a/virocon/predefined.py
+++ b/virocon/predefined.py
@@ -63,7 +63,7 @@ def get_DNVGL_Hs_Tz():
     exp3 = DependenceFunction(_exp3, bounds, latex="$a + b * \exp(c * x)$")
 
     dist_description_hs = {
-        "distribution": WeibullDistribution(),
+        "distribution": WeibullDistribution(f_gamma=0),
         "intervals": WidthOfIntervalSlicer(width=0.5),
     }
 
@@ -75,9 +75,7 @@ def get_DNVGL_Hs_Tz():
 
     dist_descriptions = [dist_description_hs, dist_description_tz]
 
-    fit_description_hs = {'method':'MM','weights':None}
-    fit_description_tz = {'method':'MM','weights':None}
-    fit_descriptions = [fit_description_hs,fit_description_tz]
+    fit_descriptions = [{'method':'MM','weights':None},None]
 
     semantics = {
         "names": ["Significant wave height", "Zero-up-crossing period"],
@@ -137,9 +135,7 @@ def get_DNVGL_Hs_U():
 
     dist_descriptions = [dist_description_hs, dist_description_u]
 
-    fit_description_hs = {'method':'MM','weights':None}
-    fit_description_u = {'method':'MM','weights':None}
-    fit_descriptions = [fit_description_hs,fit_description_u]
+    fit_descriptions = None
 
     semantics = {
         "names": ["Significant wave height", "Wind speed"],

--- a/virocon/predefined.py
+++ b/virocon/predefined.py
@@ -75,7 +75,7 @@ def get_DNVGL_Hs_Tz():
 
     dist_descriptions = [dist_description_hs, dist_description_tz]
 
-    fit_descriptions = [{"method": "MM", "weights": None}, None]
+    fit_descriptions = [{"method": "MoM", "weights": None}, None]
 
     semantics = {
         "names": ["Significant wave height", "Zero-up-crossing period"],

--- a/virocon/predefined.py
+++ b/virocon/predefined.py
@@ -63,7 +63,7 @@ def get_DNVGL_Hs_Tz():
     exp3 = DependenceFunction(_exp3, bounds, latex="$a + b * \exp(c * x)$")
 
     dist_description_hs = {
-        "distribution": WeibullDistribution(f_gamma=0),
+        "distribution": WeibullDistribution(),
         "intervals": WidthOfIntervalSlicer(width=0.5),
     }
 

--- a/virocon/predefined.py
+++ b/virocon/predefined.py
@@ -75,7 +75,7 @@ def get_DNVGL_Hs_Tz():
 
     dist_descriptions = [dist_description_hs, dist_description_tz]
 
-    fit_descriptions = [{"method": "MoM", "weights": None}, None]
+    fit_descriptions = [{"method": "MoM"}, None]
 
     semantics = {
         "names": ["Significant wave height", "Zero-up-crossing period"],

--- a/virocon/predefined.py
+++ b/virocon/predefined.py
@@ -75,7 +75,9 @@ def get_DNVGL_Hs_Tz():
 
     dist_descriptions = [dist_description_hs, dist_description_tz]
 
-    fit_descriptions = None
+    fit_description_hs = {'method':'MM','weights':None}
+    fit_description_tz = {'method':'MM','weights':None}
+    fit_descriptions = [fit_description_hs,fit_description_tz]
 
     semantics = {
         "names": ["Significant wave height", "Zero-up-crossing period"],
@@ -135,7 +137,9 @@ def get_DNVGL_Hs_U():
 
     dist_descriptions = [dist_description_hs, dist_description_u]
 
-    fit_descriptions = None
+    fit_description_hs = {'method':'MM','weights':None}
+    fit_description_u = {'method':'MM','weights':None}
+    fit_descriptions = [fit_description_hs,fit_description_u]
 
     semantics = {
         "names": ["Significant wave height", "Wind speed"],
@@ -501,3 +505,4 @@ def get_Nonzero_EW_Hs_S():
     }
 
     return dist_descriptions, fit_descriptions, semantics, transformations
+


### PR DESCRIPTION
Here is the PR mentioned to fix #227 . I added the "method" keyword to the _fit_mle() method of all distributions, although I only tested method of moments for weibull. I also changed the default to method of moments for weibull (hs) in the predefined. Maybe it could be argued that the lognormal (tp) should also be fitted with MM, but this didn't make much of a difference, so I left it as is.

About the literature - In DNV GL RP 2017, they say this about fitting in general:

> 3.6.1.6 When fitting probability distributions to data, different fitting techniques can be applied; notably
method of moments (MOM), least squares methods (LS) and maximum likelihood estimation (MLE).

But there is nothing more specific about the joint distribution models. I looked at a few papers by Bitner-Gregersen (cited by DNV RP) but found nothing more specific.

Here are all the datasets, with 1, 10, 100 and 1000 year contours for DNV GL model with both MLE and MM, and the OMAE model for reference..

![image](https://github.com/user-attachments/assets/6790ad56-7aa2-4c44-8a48-31e2353bc7dc)
![image](https://github.com/user-attachments/assets/17292acd-10ce-4ab0-a96e-267ec4da76fc)
![image](https://github.com/user-attachments/assets/919d335b-f0d0-4f3d-b2a1-de181bebaa74)
![image](https://github.com/user-attachments/assets/c6f1e637-3753-4e6e-8111-2a98e9151bd7)
