### PR TITLE
Use official ruff GitHub action for linting + checking code format

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -8,10 +8,11 @@ jobs:
       - uses: astral-sh/ruff-action@v3
         with:
           args: check . # Run linting, fails on issues.
-      - name: Check formatting
+      - name: Check formatting # Run formatting, fails on issues.
         run: |
           ruff format --check . || (
             echo "Formatting issues detected. Showing diff:" &&
             ruff format . &&
             git diff
+            exit 1
           )

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -9,4 +9,9 @@ jobs:
         with:
           args: check . # Run linting, fails on issues.
       - name: Check formatting
-        run: ruff format --check . # Ensures formatting is correct, fails otherwise.
+        run: |
+          ruff format --check . || (
+            echo "Formatting issues detected. Showing diff:" &&
+            ruff format . &&
+            git diff
+          )

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,8 +1,12 @@
 name: Ruff
-on: [ push, pull_request ]
+on: [push, pull_request]
 jobs:
   ruff:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: chartboost/ruff-action@v1
+      - uses: astral-sh/ruff-action@v3
+        with:
+          args: check . # Run linting, fails on issues.
+      - name: Check formatting
+        run: ruff format --check . # Ensures formatting is correct, fails otherwise.

--- a/virocon/_fitting.py
+++ b/virocon/_fitting.py
@@ -6,8 +6,6 @@ import numpy as np
 
 from scipy.optimize import minimize, curve_fit
 
-# %% unconstrained fitting
-
 
 def fit_function(func, x, y, p0, method, bounds, weights=None):
     if bounds is not None:
@@ -40,9 +38,6 @@ def convert_bounds_for_curve_fit(bounds):
     return [lower_bounds, upper_bounds]
 
 
-# %% constrained fitting
-
-
 def get_least_squares_error_func(func, x, y):
     def least_squares_error_func(p):
         return np.sum((func(x, *p) - y) ** 2)
@@ -65,10 +60,8 @@ def bounds_to_constraints(bounds):
 
 
 def fit_constrained_function(func, x, y, p0, method, bounds, constraints, weights=None):
-    # p0 = np.asarray(p0)
     if method == "lsq":
         error_func = get_least_squares_error_func(func, x, y)
-        # cost_func
     else:
         # TODO implement WLSQ
         raise NotImplementedError(
@@ -78,44 +71,13 @@ def fit_constrained_function(func, x, y, p0, method, bounds, constraints, weight
     if constraints is None:
         constraints = []
 
-    # constraints = list(constraints)
-    # if bounds is not None:
-    #     constraints.extend(bounds_to_constraints(bounds))
-
     result = minimize(
         error_func,
         p0,
         method="SLSQP",
-        # jac="cs",
-        # constraints=constraints,
         bounds=bounds,
-        # tol=1E-15
         options={"eps": 1e-15},
-        # options={'ftol': 1e-15, },#"disp":True},
     )
-    # result = minimize(error_func, p0,
-    #                   method="trust-constr",
-    #                   #jac="3-point",
-    #                   #constraints=constraints,
-    #                   bounds=bounds,
-    #                   #tol=1E-11
-    #                   options={"initial_tr_radius": 10, },#"disp":True},
-    #                   )
-
-    # minimizer_kwargs = {"method" : "SLSQP",
-    #                     "constraints" : constraints,
-    #                     "bounds" : bounds,
-    #                     "options" : {'ftol': 1e-15, "maxiter" : 1000},#"disp":True},
-    #                     #"options": {"eps" : 1E-2}
-    #                     }
-    # minimizer_kwargs = {"method" : "SLSQP",
-    #                     "constraints" : constraints,
-    #                     "bounds" : None,
-    #                     #"options" : {'ftol': 1e-15, "maxiter" : 1000},#"disp":True},
-    #                     #"options": {"eps" : 1E-2}
-    #                     }
-    # res = basinhopping(error_func, p0, minimizer_kwargs=minimizer_kwargs, seed=42, )#stepsize=2, T=100)
-    # result = res.lowest_optimization_result
     if not result.success:
         raise RuntimeError(
             "Error during fitting in scipy.optimize.minimize. "

--- a/virocon/_fitting.py
+++ b/virocon/_fitting.py
@@ -65,7 +65,7 @@ def fit_constrained_function(func, x, y, p0, method, bounds, constraints, weight
     else:
         # TODO implement WLSQ
         raise NotImplementedError(
-            "At this time only least squares (lsq) " "fitting is supported."
+            "At this time only least squares (lsq) fitting is supported."
         )
 
     if constraints is None:


### PR DESCRIPTION
Resolves #229

This PR
 * replaces [ChartBoost's outdated GitHub action](https://github.com/ChartBoost/ruff-action?tab=readme-ov-file) with the [official ruff GitHub action ](https://github.com/astral-sh/ruff-action) in the workflow
 * uses ruff to explicitly lint the code and check its formatting in the workflow
 * autoformats the file `_fitting.py` and deletes comments in it to avoid the updated workflow fails ;-)