### PR TITLE
Plotting options and compatibility with matplotlib>3.8

### DIFF
--- a/virocon/plotting.py
+++ b/virocon/plotting.py
@@ -456,6 +456,8 @@ def plot_2D_isodensity(
     levels=None,
     ax=None,
     n_grid_steps=250,
+    cmap=None,
+    **kwargs,
 ):
     """
     Plot isodensity contours and a data sample for a 2D model.
@@ -486,6 +488,11 @@ def plot_2D_isodensity(
     ax : matplotlib Axes, optional
         Matplotlib axes object to use for plotting. If None (default) a new
         figure will be created.
+    cmap : matplotlib colormap, optional
+        The colormap to use for the isodensity contours.
+    **kwargs : keyword arguments
+        Any other keyword arguments for matplotlib.pyplot.contour().
+        Example: linewidths=[1,2,3], linestyles=["solid","dotted","dashed"]
 
     Returns
     -------
@@ -560,13 +567,14 @@ def plot_2D_isodensity(
             ::-1
         ]
 
-    cmap = _rainbow_PuRd()
+    if cmap is None:
+        cmap = _rainbow_PuRd()
     colors = cmap(np.linspace(0, 1, num=n_levels))
-    CS = ax.contour(X, Y, Z, levels=levels, colors=colors)
-    proxies = [plt.Line2D([], [], color=pc.get_edgecolor()[0]) for pc in CS.collections]
+    CS = ax.contour(X, Y, Z, levels=levels, colors=colors, **kwargs)
+    handles, _ = CS.legend_elements()
     ax.legend(
-        proxies,
-        lvl_labels,
+        handles=handles,
+        labels=lvl_labels,
         loc="upper left",
         ncol=1,
         frameon=False,

--- a/virocon/plotting.py
+++ b/virocon/plotting.py
@@ -337,7 +337,7 @@ def plot_histograms_of_interval_distributions(
     plot_pdf: boolean, optional
         Whether the fitted probability density should be plotted. Defaults to True.
     max_cols : int, default 4
-        Number of columns (subfigures horizontally).
+        Maximum number of columns (subfigures horizontally).
 
     Returns
     -------

--- a/virocon/plotting.py
+++ b/virocon/plotting.py
@@ -601,6 +601,7 @@ def plot_2D_contour(
     semantics=None,
     swap_axis=False,
     ax=None,
+    **kwargs,
 ):
     """
     Plot a 2D contour.
@@ -627,6 +628,9 @@ def plot_2D_contour(
     ax : matplotlib Axes, optional
         Matplotlib axes object to use for plotting. If None (default) a new
         figure will be created.
+    **kwargs : keyword arguments
+        Any other keyword arguments to pass to the matplotlib plotting function,
+        Example: color="blue", linewidth=2, label="100-year contour"
 
     Returns
     -------
@@ -689,7 +693,9 @@ def plot_2D_contour(
     # was reverted as we were not sure about the reason.
     # https://github.com/virocon-organization/virocon/commit/45482e0b5ff2d21c594f0e292b3db9c971881b5c
     # https://github.com/virocon-organization/virocon/pull/124#discussion_r684193507
-    ax.plot(x, y, c="#BB5566")
+    if "color" not in kwargs and "c" not in kwargs:
+        kwargs["c"] = "#BB5566"
+    ax.plot(x, y, **kwargs)
     # ax.plot(np.asarray(x, dtype=object), np.asarray(y, dtype=object), c="#BB5566")
 
     x_name = semantics["names"][x_idx]

--- a/virocon/plotting.py
+++ b/virocon/plotting.py
@@ -572,8 +572,8 @@ def plot_2D_isodensity(
     elif isinstance(cmap, str):
         cmap = plt.get_cmap(cmap)
     colors = cmap(np.linspace(0, 1, num=n_levels))
-    plot_kwargs = {} if plot_kwargs is None else plot_kwargs
-    CS = ax.contour(X, Y, Z, levels=levels, colors=colors, **plot_kwargs)
+    contour_kwargs = {} if contour_kwargs is None else contour_kwargs
+    CS = ax.contour(X, Y, Z, levels=levels, colors=colors, **contour_kwargs)
     handles, _ = CS.legend_elements()
     ax.legend(
         handles=handles,

--- a/virocon/plotting.py
+++ b/virocon/plotting.py
@@ -87,16 +87,12 @@ def get_default_semantics(n_dim):
 def _get_n_axes(n_intervals, max_cols=4):
     if n_intervals < max_cols**2:
         table = np.array(
-            [
-                (rows, cols)
-                for cols in range(1, max_cols + 1)
-                for rows in range(1, cols + 1)
-            ]
+            [(rows, cols) for cols in range(max_cols + 1) for rows in range(cols + 1)]
         )
         table = table[np.prod(table, axis=1) >= n_intervals]
         (nrows, ncols) = table[np.argmin(np.prod(table, axis=1) - n_intervals)]
     else:
-        nrows = 1 + ((n_intervals - 1) // max_cols)
+        nrows = np.ceil(n_intervals / max_cols).astype(int)
         ncols = max_cols
 
     fig, axes = plt.subplots(

--- a/virocon/plotting.py
+++ b/virocon/plotting.py
@@ -569,6 +569,8 @@ def plot_2D_isodensity(
 
     if cmap is None:
         cmap = _rainbow_PuRd()
+    elif isinstance(cmap, str):
+        cmap = plt.get_cmap(cmap)
     colors = cmap(np.linspace(0, 1, num=n_levels))
     CS = ax.contour(X, Y, Z, levels=levels, colors=colors, **kwargs)
     handles, _ = CS.legend_elements()

--- a/virocon/plotting.py
+++ b/virocon/plotting.py
@@ -84,34 +84,23 @@ def get_default_semantics(n_dim):
     return semantics
 
 
-def _get_n_axes(n_intervals):
-    max_intervals = 16
-    if n_intervals > max_intervals:
-        raise NotImplementedError(
-            f"Automatic axes creation is only supported for up to {max_intervals} intervals."
+def _get_n_axes(n_intervals, max_cols=4):
+    if n_intervals < max_cols**2:
+        table = np.array(
+            [
+                (rows, cols)
+                for cols in range(1, max_cols + 1)
+                for rows in range(1, cols + 1)
+            ]
         )
-
-    table = [
-        (1, 1),
-        (1, 2),
-        (1, 3),
-        (2, 2),
-        (2, 3),
-        (2, 3),
-        (3, 3),
-        (3, 3),
-        (3, 3),
-        (4, 4),
-        (4, 4),
-        (4, 4),
-        (4, 4),
-        (4, 4),
-        (4, 4),
-        (4, 4),
-    ]
+        table = table[np.prod(table, axis=1) >= n_intervals]
+        (nrows, ncols) = table[np.argmin(np.prod(table, axis=1) - n_intervals)]
+    else:
+        nrows = 1 + ((n_intervals - 1) // max_cols)
+        ncols = max_cols
 
     fig, axes = plt.subplots(
-        *table[n_intervals], sharex=True, sharey=True, squeeze=False
+        nrows=nrows, ncols=ncols, sharex=True, sharey=True, squeeze=False
     )
     return fig, axes.ravel()
 
@@ -325,7 +314,11 @@ def plot_dependence_functions(model, semantics=None, par_rename={}, axes=None):
 
 
 def plot_histograms_of_interval_distributions(
-    model, sample, semantics=None, plot_pdf=True
+    model,
+    sample,
+    semantics=None,
+    plot_pdf=True,
+    max_cols=4,
 ):
     """
     Plot histograms of all model dimensions.
@@ -343,6 +336,8 @@ def plot_histograms_of_interval_distributions(
         The description of the model. If None (the default) generic semantics will be used.
     plot_pdf: boolean, optional
         Whether the fitted probability density should be plotted. Defaults to True.
+    max_cols : int, default 4
+        Number of columns (subfigures horizontally).
 
     Returns
     -------
@@ -419,7 +414,7 @@ def plot_histograms_of_interval_distributions(
                     np.sort(data_intervals[i]), np.sort(cond_dist.data_intervals[i])
                 )
 
-            fig, axes = _get_n_axes(n_intervals)
+            fig, axes = _get_n_axes(n_intervals, max_cols=max_cols)
             for interval_idx in range(n_intervals):
                 cond_val = conditioning_values[interval_idx]
                 data = data_intervals[interval_idx]

--- a/virocon/plotting.py
+++ b/virocon/plotting.py
@@ -457,7 +457,7 @@ def plot_2D_isodensity(
     ax=None,
     n_grid_steps=250,
     cmap=None,
-    **kwargs,
+    contour_kwargs=None,
 ):
     """
     Plot isodensity contours and a data sample for a 2D model.
@@ -490,9 +490,9 @@ def plot_2D_isodensity(
         figure will be created.
     cmap : matplotlib colormap, optional
         The colormap to use for the isodensity contours.
-    **kwargs : keyword arguments
+    contour_kwargs : dict
         Any other keyword arguments for matplotlib.pyplot.contour().
-        Example: linewidths=[1,2,3], linestyles=["solid","dotted","dashed"]
+        Example: {"linewidths": [1,2,3], "linestyles": ["solid","dotted","dashed"]}
 
     Returns
     -------
@@ -572,7 +572,8 @@ def plot_2D_isodensity(
     elif isinstance(cmap, str):
         cmap = plt.get_cmap(cmap)
     colors = cmap(np.linspace(0, 1, num=n_levels))
-    CS = ax.contour(X, Y, Z, levels=levels, colors=colors, **kwargs)
+    plot_kwargs = {} if plot_kwargs is None else plot_kwargs
+    CS = ax.contour(X, Y, Z, levels=levels, colors=colors, **plot_kwargs)
     handles, _ = CS.legend_elements()
     ax.legend(
         handles=handles,
@@ -603,7 +604,7 @@ def plot_2D_contour(
     semantics=None,
     swap_axis=False,
     ax=None,
-    **kwargs,
+    plot_kwargs=None,
 ):
     """
     Plot a 2D contour.
@@ -630,9 +631,9 @@ def plot_2D_contour(
     ax : matplotlib Axes, optional
         Matplotlib axes object to use for plotting. If None (default) a new
         figure will be created.
-    **kwargs : keyword arguments
+    plot_kwargs : dict
         Any other keyword arguments to pass to the matplotlib plotting function,
-        Example: color="blue", linewidth=2, label="100-year contour"
+        Example: {"color": "blue", "linewidth": 2, "label": "100-year contour"
 
     Returns
     -------
@@ -695,9 +696,10 @@ def plot_2D_contour(
     # was reverted as we were not sure about the reason.
     # https://github.com/virocon-organization/virocon/commit/45482e0b5ff2d21c594f0e292b3db9c971881b5c
     # https://github.com/virocon-organization/virocon/pull/124#discussion_r684193507
-    if "color" not in kwargs and "c" not in kwargs:
-        kwargs["c"] = "#BB5566"
-    ax.plot(x, y, **kwargs)
+    plot_kwargs = {} if plot_kwargs is None else plot_kwargs
+    if "color" not in plot_kwargs and "c" not in plot_kwargs:
+        plot_kwargs["c"] = "#BB5566"
+    ax.plot(x, y, **plot_kwargs)
     # ax.plot(np.asarray(x, dtype=object), np.asarray(y, dtype=object), c="#BB5566")
 
     x_name = semantics["names"][x_idx]

--- a/virocon/plotting.py
+++ b/virocon/plotting.py
@@ -85,9 +85,17 @@ def get_default_semantics(n_dim):
 
 
 def _get_n_axes(n_intervals, max_cols=4):
-    if n_intervals < max_cols**2:
+    if n_intervals <= 0:
+        raise ValueError(
+            f"n_intervals should be a positive integer, but got {n_intervals}."
+        )
+    elif n_intervals < max_cols**2:
         table = np.array(
-            [(rows, cols) for cols in range(max_cols + 1) for rows in range(cols + 1)]
+            [
+                (rows, cols)
+                for cols in range(1, max_cols + 1)
+                for rows in range(1, cols + 1)
+            ]
         )
         table = table[np.prod(table, axis=1) >= n_intervals]
         (nrows, ncols) = table[np.argmin(np.prod(table, axis=1) - n_intervals)]


### PR DESCRIPTION
These are some suggestions to allow more customization of plots, without changing any default behavior, by adding **kwargs.

Changes:
1. Axes creation for interval distributions (_get_n_axes) should now work with any number of intervals, and you can specify maximum number of subplot columns with max_cols parameter (default 4).
2. Changed the method for getting the contour label handles in the isodensity plot, because it was deprecated from matplotlib>3.8. 
3. Allowed keyword arguments (**kwargs) in isodensity plot and contour plot, which are passed directly to the respective matplotlib plotting functions. This allows more customization, such as:
```python
fig,ax = plt.subplots()
for return_period in [1,10,100]:
    alpha = virocon.calculate_alpha(1,return_period)
    contour = virocon.IFORMContour(model,alpha)
    virocon.plot_2D_contour(contour,data,semantics=semantics,swap_axis=True,c=None,label=f'{return_period} year contour',ax=ax)
plt.legend()
```
![image](https://github.com/user-attachments/assets/d27cf3ad-cefd-4594-8010-7d0f2b791039)
and
```python
virocon.plot_2D_isodensity(model,data,semantics,swap_axis=True,cmap="viridis",
    linestyles=["dotted","solid","dashed","dashdot","dotted"])
```
![image](https://github.com/user-attachments/assets/e760e4d7-ca20-4e87-9b7d-395864ebebdc)

